### PR TITLE
Fix crash of 1.4.30 on centos 5.7

### DIFF
--- a/src/connections.c
+++ b/src/connections.c
@@ -1360,9 +1360,7 @@ connection *connection_accept(server *srv, server_socket *srv_socket) {
 			}
 
 			con->renegotiations = 0;
-#ifndef OPENSSL_NO_TLSEXT
 			SSL_set_app_data(con->ssl, con);
-#endif
 			SSL_set_accept_state(con->ssl);
 			con->conf.is_ssl=1;
 


### PR DESCRIPTION
SSL_set_app_data does not depend on OPENSSL_NO_TLSEXT. remove the #ifndef. This fixes a crash on e.g. centos 5.7. Reported and patch verified by carpii on #lighttpd.
