### PR TITLE
performance: use Linux extended syscalls and flags

### DIFF
--- a/src/fdevent.h
+++ b/src/fdevent.h
@@ -204,7 +204,14 @@ int fdevent_register(fdevents *ev, int fd, fdevent_handler handler, void *ctx);
 int fdevent_unregister(fdevents *ev, int fd);
 
 void fd_close_on_exec(int fd);
+int fdevent_fcntl_hook(fdevents *ev, int fd);
 int fdevent_fcntl_set(fdevents *ev, int fd);
+int fdevent_fcntl_sock(fdevents *ev, int fd);
+int fdevent_fcntl_nonblock(fdevents *ev, int fd);
+int fdevent_socket_cloexec(int domain, int type, int protocol);
+int fdevent_socket_nb_cloexec(int domain, int type, int protocol);
+int fdevent_open_cloexec(const char *pathname, int flags);
+int fdevent_open_mode_cloexec(const char *pathname, int flags, mode_t mode);
 
 int fdevent_select_init(fdevents *ev);
 int fdevent_poll_init(fdevents *ev);

--- a/src/mod_accesslog.c
+++ b/src/mod_accesslog.c
@@ -23,10 +23,6 @@
 # include <syslog.h>
 #endif
 
-#ifndef O_CLOEXEC
-#define O_CLOEXEC 0
-#endif
-
 typedef struct {
 	char key;
 	enum {
@@ -667,13 +663,12 @@ SIGHUP_FUNC(log_access_cycle) {
 			if (-1 != s->log_access_fd) close(s->log_access_fd);
 
 			if (-1 == (s->log_access_fd =
-				   open(s->access_logfile->ptr, O_APPEND | O_WRONLY | O_CREAT | O_LARGEFILE | O_CLOEXEC, 0644))) {
+				   fdevent_open_mode_cloexec(s->access_logfile->ptr, O_APPEND | O_WRONLY | O_CREAT | O_LARGEFILE, 0644))) {
 
 				log_error_write(srv, __FILE__, __LINE__, "ss", "cycling access-log failed:", strerror(errno));
 
 				return HANDLER_ERROR;
 			}
-			if (!O_CLOEXEC) fd_close_on_exec(s->log_access_fd);
 		}
 	}
 

--- a/src/mod_accesslog.c
+++ b/src/mod_accesslog.c
@@ -23,6 +23,10 @@
 # include <syslog.h>
 #endif
 
+#ifndef O_CLOEXEC
+#define O_CLOEXEC 0
+#endif
+
 typedef struct {
 	char key;
 	enum {
@@ -663,13 +667,13 @@ SIGHUP_FUNC(log_access_cycle) {
 			if (-1 != s->log_access_fd) close(s->log_access_fd);
 
 			if (-1 == (s->log_access_fd =
-				   open(s->access_logfile->ptr, O_APPEND | O_WRONLY | O_CREAT | O_LARGEFILE, 0644))) {
+				   open(s->access_logfile->ptr, O_APPEND | O_WRONLY | O_CREAT | O_LARGEFILE | O_CLOEXEC, 0644))) {
 
 				log_error_write(srv, __FILE__, __LINE__, "ss", "cycling access-log failed:", strerror(errno));
 
 				return HANDLER_ERROR;
 			}
-			fd_close_on_exec(s->log_access_fd);
+			if (!O_CLOEXEC) fd_close_on_exec(s->log_access_fd);
 		}
 	}
 

--- a/src/mod_fastcgi.c
+++ b/src/mod_fastcgi.c
@@ -965,7 +965,7 @@ static int fcgi_spawn_connection(server *srv,
 		buffer_append_int(proc->connection_name, proc->port);
 	}
 
-	if (-1 == (fcgi_fd = socket(fcgi_addr->sa_family, SOCK_STREAM, 0))) {
+	if (-1 == (fcgi_fd = socket(fcgi_addr->sa_family, SOCK_STREAM | SOCK_CLOEXEC, 0))) {
 		log_error_write(srv, __FILE__, __LINE__, "ss",
 				"failed:", strerror(errno));
 		return -1;
@@ -984,7 +984,7 @@ static int fcgi_spawn_connection(server *srv,
 		close(fcgi_fd);
 
 		/* reopen socket */
-		if (-1 == (fcgi_fd = socket(fcgi_addr->sa_family, SOCK_STREAM, 0))) {
+		if (-1 == (fcgi_fd = socket(fcgi_addr->sa_family, SOCK_STREAM | SOCK_CLOEXEC, 0))) {
 			log_error_write(srv, __FILE__, __LINE__, "ss",
 				"socket failed:", strerror(errno));
 			return -1;
@@ -1036,6 +1036,8 @@ static int fcgi_spawn_connection(server *srv,
 				dup2(fcgi_fd, FCGI_LISTENSOCK_FILENO);
 				close(fcgi_fd);
 			}
+			else if (SOCK_CLOEXEC)
+				fcntl(fcgi_fd, F_SETFD, 0); /* clear cloexec */
 
 			/* we don't need the client socket */
 			for (i = 3; i < 256; i++) {
@@ -2926,7 +2928,7 @@ static handler_t fcgi_write_request(server *srv, handler_ctx *hctx) {
 			if (proc->load < hctx->proc->load) hctx->proc = proc;
 		}
 
-		if (-1 == (hctx->fd = socket(host->family, SOCK_STREAM, 0))) {
+		if (-1 == (hctx->fd = socket(host->family, SOCK_STREAM | SOCK_CLOEXEC | SOCK_NONBLOCK, 0))) {
 			if (errno == EMFILE ||
 			    errno == EINTR) {
 				log_error_write(srv, __FILE__, __LINE__, "sd",
@@ -2943,9 +2945,15 @@ static handler_t fcgi_write_request(server *srv, handler_ctx *hctx) {
 
 		srv->cur_fds++;
 
-		fdevent_register(srv->ev, hctx->fd, fcgi_handle_fdevent, hctx);
+		if (-1 == fdevent_register(srv->ev, hctx->fd, fcgi_handle_fdevent, hctx)) {
+			log_error_write(srv, __FILE__, __LINE__, "ss",
+					"fdevent_register failed:", strerror(errno));
 
-		if (-1 == fdevent_fcntl_set(srv->ev, hctx->fd)) {
+			return HANDLER_ERROR;
+		}
+
+		if ((!SOCK_CLOEXEC || !SOCK_NONBLOCK)
+		    && -1 == fdevent_fcntl_set(srv->ev, hctx->fd)) {
 			log_error_write(srv, __FILE__, __LINE__, "ss",
 					"fcntl failed:", strerror(errno));
 

--- a/src/mod_proxy.c
+++ b/src/mod_proxy.c
@@ -780,14 +780,14 @@ static handler_t proxy_write_request(server *srv, handler_ctx *hctx) {
 #endif
 #if defined(HAVE_IPV6) && defined(HAVE_INET_PTON)
 		if (strstr(host->host->ptr,":")) {
-			if (-1 == (hctx->fd = socket(AF_INET6, SOCK_STREAM | SOCK_CLOEXEC | SOCK_NONBLOCK, 0))) {
+			if (-1 == (hctx->fd = fdevent_socket_nb_cloexec(AF_INET6, SOCK_STREAM, 0))) {
 				log_error_write(srv, __FILE__, __LINE__, "ss", "socket failed: ", strerror(errno));
 				return HANDLER_ERROR;
 			}
 		} else
 #endif
 		{
-			if (-1 == (hctx->fd = socket(AF_INET, SOCK_STREAM | SOCK_CLOEXEC | SOCK_NONBLOCK, 0))) {
+			if (-1 == (hctx->fd = fdevent_socket_nb_cloexec(AF_INET, SOCK_STREAM, 0))) {
 				log_error_write(srv, __FILE__, __LINE__, "ss", "socket failed: ", strerror(errno));
 				return HANDLER_ERROR;
 			}
@@ -799,14 +799,11 @@ static handler_t proxy_write_request(server *srv, handler_ctx *hctx) {
 
 		if (-1 == fdevent_register(srv->ev, hctx->fd, proxy_handle_fdevent, hctx)) {
 			log_error_write(srv, __FILE__, __LINE__, "ss", "fdevent_register failed: ", strerror(errno));
-
 			return HANDLER_ERROR;
 		}
 
-		if ((!SOCK_CLOEXEC || !SOCK_NONBLOCK)
-		    && -1 == fdevent_fcntl_set(srv->ev, hctx->fd)) {
+		if (-1 == fdevent_fcntl_hook(srv->ev, hctx->fd)) {
 			log_error_write(srv, __FILE__, __LINE__, "ss", "fcntl failed: ", strerror(errno));
-
 			return HANDLER_ERROR;
 		}
 

--- a/src/mod_scgi.c
+++ b/src/mod_scgi.c
@@ -757,7 +757,7 @@ static int scgi_spawn_connection(server *srv,
 		scgi_addr = (struct sockaddr *) &scgi_addr_in;
 	}
 
-	if (-1 == (scgi_fd = socket(scgi_addr->sa_family, SOCK_STREAM | SOCK_CLOEXEC, 0))) {
+	if (-1 == (scgi_fd = fdevent_socket_cloexec(scgi_addr->sa_family, SOCK_STREAM, 0))) {
 		log_error_write(srv, __FILE__, __LINE__, "ss",
 				"failed:", strerror(errno));
 		return -1;
@@ -775,7 +775,7 @@ static int scgi_spawn_connection(server *srv,
 		close(scgi_fd);
 
 		/* reopen socket */
-		if (-1 == (scgi_fd = socket(scgi_addr->sa_family, SOCK_STREAM | SOCK_CLOEXEC, 0))) {
+		if (-1 == (scgi_fd = fdevent_socket_cloexec(scgi_addr->sa_family, SOCK_STREAM, 0))) {
 			log_error_write(srv, __FILE__, __LINE__, "ss",
 				"socket failed:", strerror(errno));
 			return -1;
@@ -824,8 +824,10 @@ static int scgi_spawn_connection(server *srv,
 				dup2(scgi_fd, 0);
 				close(scgi_fd);
 			}
-			else if (SOCK_CLOEXEC)
+#ifdef SOCK_CLOEXEC
+			else
 				fcntl(scgi_fd, F_SETFD, 0); /* clear cloexec */
+#endif
 
 			/* we don't need the client socket */
 			for (fd = 3; fd < 256; fd++) {
@@ -2271,7 +2273,7 @@ static handler_t scgi_write_request(server *srv, handler_ctx *hctx) {
 
 	switch(hctx->state) {
 	case FCGI_STATE_INIT:
-		if (-1 == (hctx->fd = socket(host->family, SOCK_STREAM | SOCK_CLOEXEC | SOCK_NONBLOCK, 0))) {
+		if (-1 == (hctx->fd = fdevent_socket_nb_cloexec(host->family, SOCK_STREAM, 0))) {
 			if (errno == EMFILE ||
 			    errno == EINTR) {
 				log_error_write(srv, __FILE__, __LINE__, "sd",
@@ -2296,11 +2298,9 @@ static handler_t scgi_write_request(server *srv, handler_ctx *hctx) {
 			return HANDLER_ERROR;
 		}
 
-		if ((!SOCK_CLOEXEC || !SOCK_NONBLOCK)
-		    && -1 == fdevent_fcntl_set(srv->ev, hctx->fd)) {
+		if (-1 == fdevent_fcntl_hook(srv->ev, hctx->fd)) {
 			log_error_write(srv, __FILE__, __LINE__, "ss",
 					"fcntl failed: ", strerror(errno));
-
 			return HANDLER_ERROR;
 		}
 

--- a/src/mod_scgi.c
+++ b/src/mod_scgi.c
@@ -757,7 +757,7 @@ static int scgi_spawn_connection(server *srv,
 		scgi_addr = (struct sockaddr *) &scgi_addr_in;
 	}
 
-	if (-1 == (scgi_fd = socket(scgi_addr->sa_family, SOCK_STREAM, 0))) {
+	if (-1 == (scgi_fd = socket(scgi_addr->sa_family, SOCK_STREAM | SOCK_CLOEXEC, 0))) {
 		log_error_write(srv, __FILE__, __LINE__, "ss",
 				"failed:", strerror(errno));
 		return -1;
@@ -775,7 +775,7 @@ static int scgi_spawn_connection(server *srv,
 		close(scgi_fd);
 
 		/* reopen socket */
-		if (-1 == (scgi_fd = socket(scgi_addr->sa_family, SOCK_STREAM, 0))) {
+		if (-1 == (scgi_fd = socket(scgi_addr->sa_family, SOCK_STREAM | SOCK_CLOEXEC, 0))) {
 			log_error_write(srv, __FILE__, __LINE__, "ss",
 				"socket failed:", strerror(errno));
 			return -1;
@@ -824,6 +824,8 @@ static int scgi_spawn_connection(server *srv,
 				dup2(scgi_fd, 0);
 				close(scgi_fd);
 			}
+			else if (SOCK_CLOEXEC)
+				fcntl(scgi_fd, F_SETFD, 0); /* clear cloexec */
 
 			/* we don't need the client socket */
 			for (fd = 3; fd < 256; fd++) {
@@ -2269,7 +2271,7 @@ static handler_t scgi_write_request(server *srv, handler_ctx *hctx) {
 
 	switch(hctx->state) {
 	case FCGI_STATE_INIT:
-		if (-1 == (hctx->fd = socket(host->family, SOCK_STREAM, 0))) {
+		if (-1 == (hctx->fd = socket(host->family, SOCK_STREAM | SOCK_CLOEXEC | SOCK_NONBLOCK, 0))) {
 			if (errno == EMFILE ||
 			    errno == EINTR) {
 				log_error_write(srv, __FILE__, __LINE__, "sd",
@@ -2286,9 +2288,16 @@ static handler_t scgi_write_request(server *srv, handler_ctx *hctx) {
 
 		srv->cur_fds++;
 
-		fdevent_register(srv->ev, hctx->fd, scgi_handle_fdevent, hctx);
 
-		if (-1 == fdevent_fcntl_set(srv->ev, hctx->fd)) {
+		if (-1 == fdevent_register(srv->ev, hctx->fd, scgi_handle_fdevent, hctx)) {
+			log_error_write(srv, __FILE__, __LINE__, "ss",
+					"fdevent_register failed: ", strerror(errno));
+
+			return HANDLER_ERROR;
+		}
+
+		if ((!SOCK_CLOEXEC || !SOCK_NONBLOCK)
+		    && -1 == fdevent_fcntl_set(srv->ev, hctx->fd)) {
 			log_error_write(srv, __FILE__, __LINE__, "ss",
 					"fcntl failed: ", strerror(errno));
 

--- a/src/network.c
+++ b/src/network.c
@@ -367,7 +367,7 @@ static int network_server_init(server *srv, buffer *host_token, specific_config 
 	if (AF_UNIX == srv_socket->addr.plain.sa_family) {
 		/* check if the socket exists and try to connect to it. */
 		force_assert(host); /*(static analysis hint)*/
-		if (-1 == (srv_socket->fd = socket(srv_socket->addr.plain.sa_family, SOCK_STREAM | SOCK_CLOEXEC, 0))) {
+		if (-1 == (srv_socket->fd = fdevent_socket_cloexec(srv_socket->addr.plain.sa_family, SOCK_STREAM, 0))) {
 			log_error_write(srv, __FILE__, __LINE__, "ss", "socket failed:", strerror(errno));
 			goto error_free_socket;
 		}
@@ -395,11 +395,11 @@ static int network_server_init(server *srv, buffer *host_token, specific_config 
 			goto error_free_socket;
 		}
 
-		fdevent_fcntl_set(srv->ev, srv_socket->fd);/* set nonblocking */
+		fdevent_fcntl_nonblock(srv->ev, srv_socket->fd);
 	} else
 #endif
 	{
-		if (-1 == (srv_socket->fd = socket(srv_socket->addr.plain.sa_family, SOCK_STREAM | SOCK_CLOEXEC | SOCK_NONBLOCK, IPPROTO_TCP))) {
+		if (-1 == (srv_socket->fd = fdevent_socket_nb_cloexec(srv_socket->addr.plain.sa_family, SOCK_STREAM, IPPROTO_TCP))) {
 			log_error_write(srv, __FILE__, __LINE__, "ss", "socket failed:", strerror(errno));
 			goto error_free_socket;
 		}
@@ -419,9 +419,6 @@ static int network_server_init(server *srv, buffer *host_token, specific_config 
 		}
 #endif
 	}
-
-	/* set FD_CLOEXEC now, fdevent_fcntl_set is called later; needed for pipe-logger forks */
-	if (!SOCK_CLOEXEC) fd_close_on_exec(srv_socket->fd);
 
 	/* */
 	srv->cur_fds = srv_socket->fd;

--- a/src/network.c
+++ b/src/network.c
@@ -367,7 +367,7 @@ static int network_server_init(server *srv, buffer *host_token, specific_config 
 	if (AF_UNIX == srv_socket->addr.plain.sa_family) {
 		/* check if the socket exists and try to connect to it. */
 		force_assert(host); /*(static analysis hint)*/
-		if (-1 == (srv_socket->fd = socket(srv_socket->addr.plain.sa_family, SOCK_STREAM, 0))) {
+		if (-1 == (srv_socket->fd = socket(srv_socket->addr.plain.sa_family, SOCK_STREAM | SOCK_CLOEXEC, 0))) {
 			log_error_write(srv, __FILE__, __LINE__, "ss", "socket failed:", strerror(errno));
 			goto error_free_socket;
 		}
@@ -394,10 +394,12 @@ static int network_server_init(server *srv, buffer *host_token, specific_config 
 
 			goto error_free_socket;
 		}
+
+		fdevent_fcntl_set(srv->ev, srv_socket->fd);/* set nonblocking */
 	} else
 #endif
 	{
-		if (-1 == (srv_socket->fd = socket(srv_socket->addr.plain.sa_family, SOCK_STREAM, IPPROTO_TCP))) {
+		if (-1 == (srv_socket->fd = socket(srv_socket->addr.plain.sa_family, SOCK_STREAM | SOCK_CLOEXEC | SOCK_NONBLOCK, IPPROTO_TCP))) {
 			log_error_write(srv, __FILE__, __LINE__, "ss", "socket failed:", strerror(errno));
 			goto error_free_socket;
 		}
@@ -419,7 +421,7 @@ static int network_server_init(server *srv, buffer *host_token, specific_config 
 	}
 
 	/* set FD_CLOEXEC now, fdevent_fcntl_set is called later; needed for pipe-logger forks */
-	fd_close_on_exec(srv_socket->fd);
+	if (!SOCK_CLOEXEC) fd_close_on_exec(srv_socket->fd);
 
 	/* */
 	srv->cur_fds = srv_socket->fd;

--- a/src/server.c
+++ b/src/server.c
@@ -1488,7 +1488,7 @@ int main (int argc, char **argv) {
 	for (i = 0; i < srv->srv_sockets.used; i++) {
 		server_socket *srv_socket = srv->srv_sockets.ptr[i];
 		if (srv->sockets_disabled) continue; /* lighttpd -1 (one-shot mode) */
-		if (-1 == fdevent_fcntl_set(srv->ev, srv_socket->fd)) {
+		if (-1 == fdevent_fcntl_sock(srv->ev, srv_socket->fd)) {
 			log_error_write(srv, __FILE__, __LINE__, "ss", "fcntl failed:", strerror(errno));
 			return -1;
 		}

--- a/src/sys-socket.h
+++ b/src/sys-socket.h
@@ -23,10 +23,4 @@
 #include <netdb.h>
 #endif
 
-#ifndef SOCK_CLOEXEC
-#define SOCK_CLOEXEC 0
-#define SOCK_NONBLOCK 0
-#define accept4(sockfd,addr,addrlen,flags)  accept((sockfd),(addr),(addrlen))
-#endif
-
 #endif

--- a/src/sys-socket.h
+++ b/src/sys-socket.h
@@ -23,4 +23,10 @@
 #include <netdb.h>
 #endif
 
+#ifndef SOCK_CLOEXEC
+#define SOCK_CLOEXEC 0
+#define SOCK_NONBLOCK 0
+#define accept4(sockfd,addr,addrlen,flags)  accept((sockfd),(addr),(addrlen))
+#endif
+
 #endif


### PR DESCRIPTION
reduce syscalls on Linux using extended syscalls and flags,
e.g. accept4(), pipe2(), O_CLOEXEC, SOCK_CLOEXEC, SOCK_NONBLOCK