### PR TITLE
Correcting stream_open() behaviour on empty files

### DIFF
--- a/src/stream.c
+++ b/src/stream.c
@@ -27,6 +27,9 @@ int stream_open(stream *f, buffer *fn) {
 		return -1;
 	}
 
+        if(f->size < 1)  /* < 1, or == 0 */
+          return -2;
+           
 	f->size = st.st_size;
 
 #ifdef HAVE_MMAP


### PR DESCRIPTION
- As it is a read-only mmap() of a file, it doesn't make sense to continue if the file is empty.
- By returning -2 in this case, the caller function can know this was the reason for the failure. (On this kind of function, it's better to assume the stream "s" was NOT initialized after a failure. The function config_parse_file() is not doing this so it's a small bug.)

NOTE: if this commit is accepted, correct any calls "if(stream_open() == -1) { errror handling }  " to "if(stream_open())" or if(stream_open() != 0).