### PR TITLE
Import explicit_bzero() and use it 

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -74,7 +74,8 @@ common_src=buffer.c log.c \
 	network_write.c network_linux_sendfile.c \
 	network_freebsd_sendfile.c network_writev.c \
 	network_solaris_sendfilev.c network_openssl.c \
-	splaytree.c status_counter.c
+	splaytree.c status_counter.c \
+	explicit_bzero.c
 
 src = server.c response.c connections.c network.c \
 	configfile.c configparser.c request.c proc_open.c
@@ -279,6 +280,7 @@ hdr = server.h buffer.h network.h log.h keyvalue.h \
 	sys-mmap.h sys-socket.h mod_cml.h mod_cml_funcs.h \
 	splaytree.h proc_open.h status_counter.h \
 	mod_magnet_cache.h \
+	explicit_bzero.h \
 	version.h
 
 DEFS= @DEFS@ -DHAVE_VERSION_H -DLIBRARY_DIR="\"$(libdir)\"" -DSBIN_DIR="\"$(sbindir)\""

--- a/src/explicit_bzero.c
+++ b/src/explicit_bzero.c
@@ -1,0 +1,18 @@
+/*
+ * Public domain.
+ * Written by Matthew Dempsky.
+ */
+
+#include <string.h>
+
+__attribute__((weak)) void
+__explicit_bzero_hook(void *buf, size_t len)
+{
+}
+
+void
+explicit_bzero(void *buf, size_t len)
+{
+	memset(buf, 0, len);
+	__explicit_bzero_hook(buf, len);
+}

--- a/src/explicit_bzero.h
+++ b/src/explicit_bzero.h
@@ -1,0 +1,2 @@
+void
+explicit_bzero(void *buf, size_t len);

--- a/src/http_auth.c
+++ b/src/http_auth.c
@@ -28,6 +28,7 @@
 #include <ctype.h>
 
 #include "md5.h"
+#include "explicit_bzero.h"
 
 #ifdef USE_OPENSSL
 #include <openssl/sha.h>
@@ -582,7 +583,7 @@ static void apr_md5_encode(const char *pw, const char *salt, char *result, size_
     /*
      * Don't leave anything around in vm they could use.
      */
-    memset(final, 0, sizeof(final));
+    explicit_bzero(final, sizeof(final));
 
 	/* FIXME
 	 */


### PR DESCRIPTION
Problem: Compilers may optimize away calls to memset due to their optimization techniques. As shown in the snippet below, memset may be optimized away as the final variable is no longer used. To prevent this, we use OpenBSD's explicit_bzero() API which is designed not to be optimized. It's stable enough that it ships in LibreSSL. Since final is sensitive, it's safer to use explicit_bzero.


-----
    /*
     * Don't leave anything around in vm they could use.
     */
    memset(final, '0', sizeof(final));

	/* FIXME
	 */
#define apr_cpystrn strncpy
    apr_cpystrn(result, passwd, nbytes - 1);
----


