### PR TITLE
check ssiexprparserAlloc() result with force assert

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -9,6 +9,7 @@ NEWS
   * [core] fix search for header end if split across chunks (fixes #2670)
   * [core] check configparserAlloc() result with force_assert
   * [mod_auth] implement and use safe_memclear, using memset_s or explicit_bzero if available (thx loganaden)
+  * [mod_ssi] check ssiexprparserAlloc() result with force assert
 
 - 1.4.37 - 2015-08-30
   * [mod_proxy] remove debug log line from error log (fixes #2659)

--- a/src/mod_ssi_expr.c
+++ b/src/mod_ssi_expr.c
@@ -6,6 +6,7 @@
 
 #include <ctype.h>
 #include <string.h>
+#include <assert.h>
 
 typedef struct {
 	const char *input;
@@ -291,6 +292,7 @@ int ssi_eval_expr(server *srv, connection *con, plugin_data *p, const char *expr
 	/* default context */
 
 	pParser = ssiexprparserAlloc( malloc );
+	force_assert(pParser);
 	token = buffer_init();
 	while((1 == (ret = ssi_expr_tokenizer(srv, con, p, &t, &token_id, token))) && context.ok) {
 		ssiexprparser(pParser, token_id, token, &context);


### PR DESCRIPTION
In case allocation fails, pParser will be Null & it is derefrenced below.