### PR TITLE
mod_ssi: enhance support for ssi vars

### DIFF
--- a/src/mod_ssi.c
+++ b/src/mod_ssi.c
@@ -457,9 +457,10 @@ static int process_ssi_stmt(server *srv, connection *con, plugin_data *p, const 
 		}
 		default: {
 			data_string *ds;
-			/* check if it is a cgi-var */
+			/* check if it is a cgi-var or a ssi-var */
 
-			if (NULL != (ds = (data_string *)array_get_element(p->ssi_cgi_env, var_val))) {
+			if (NULL != (ds = (data_string *)array_get_element(p->ssi_cgi_env, var_val)) ||
+			    NULL != (ds = (data_string *)array_get_element(p->ssi_vars, var_val))) {
 				chunkqueue_append_mem(con->write_queue, CONST_BUF_LEN(ds->value));
 			} else {
 				chunkqueue_append_mem(con->write_queue, CONST_STR_LEN("(none)"));

--- a/src/mod_ssi_expr.c
+++ b/src/mod_ssi_expr.c
@@ -207,7 +207,9 @@ static int ssi_expr_tokenizer(server *srv, connection *con, plugin_data *p,
 
 				buffer_copy_string_len(token, t->input + t->offset + 2, i-3);
 			} else {
-				for (i = 1; isalpha(t->input[t->offset + i]) || t->input[t->offset + i] == '_';  i++);
+				for (i = 1; isalpha(t->input[t->offset + i]) ||
+					    t->input[t->offset + i] == '_' ||
+					    (i > 1) && isdigit(t->input[t->offset + i]);  i++);
 
 				buffer_copy_string_len(token, t->input + t->offset + 1, i-1);
 			}


### PR DESCRIPTION
Try ssi_vars if ssi_cgi_env does not have a matching var name.
Allow var names to also include digits after the initial letter or underscore.