### PR TITLE
mod_cgi - use MAP_PRIVATE to mmap temporary file

### DIFF
--- a/src/mod_cgi.c
+++ b/src/mod_cgi.c
@@ -10,13 +10,13 @@
 #include "plugin.h"
 
 #include <sys/types.h>
+#include "sys-mmap.h"
 
 #ifdef __WIN32
 # include <winsock2.h>
 #else
 # include <sys/socket.h>
 # include <sys/wait.h>
-# include <sys/mman.h>
 # include <netinet/in.h>
 # include <arpa/inet.h>
 #endif
@@ -776,7 +776,7 @@ static int cgi_write_file_chunk_mmap(server *srv, connection *con, int fd, chunk
 		c->file.mmap.offset = mmap_align_offset(offset);
 		c->file.mmap.length = file_end - c->file.mmap.offset;
 
-		if (MAP_FAILED == (c->file.mmap.start = mmap(NULL, c->file.mmap.length, PROT_READ, MAP_SHARED, c->file.fd, c->file.mmap.offset))) {
+		if (MAP_FAILED == (c->file.mmap.start = mmap(NULL, c->file.mmap.length, PROT_READ, MAP_PRIVATE, c->file.fd, c->file.mmap.offset))) {
 			log_error_write(srv, __FILE__, __LINE__, "ssbdoo", "mmap failed:",
 				strerror(errno), c->file.name, c->file.fd, c->file.mmap.offset, (off_t) c->file.mmap.length);
 			return -1;


### PR DESCRIPTION
instead of MAP_SHARED.  flash filesystem JFFS2 does not support mmap PROT_READ MAP_SHARED, though it does support mmap PROT_READ MAP_PRIVATE
Reference: https://redmine.lighttpd.net/issues/2715

Although MAP_SHARED is preferred, CGI input body is fully collected prior to handler invoking the CGI, so the temporary file is never modified after being mapped.  Since the request input body is specific to request and is temporary file, mmap PROT_READ MAP_PRIVATE works fine.