### PR TITLE
do not propagate sighup if 0 == server.max-workers

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -1119,7 +1119,7 @@ int main (int argc, char **argv) {
 							 * 
 							 * we also send it ourself
 							 */
-							if (!forwarded_sig_hup) {
+							if (!forwarded_sig_hup && 0 != srv->srvconf.max_worker) {
 								forwarded_sig_hup = 1;
 								kill(0, SIGHUP);
 							}


### PR DESCRIPTION
reduce impact of sighup on child processes, such as piped loggers, by not forwarding SIGHUP signal unless server.max-workers configured

For those configuring server.max-workers, it is recommended that piped loggers be used to avoid log corruption, and then admins can avoid sending lighttpd SIGHUP as there is currently no benefit to doing so with the standard modules (beyond that of log rotation of non-piped access and error logs).