### PR TITLE
[mod_cgi] issue trace and exit if execve() fails

### DIFF
--- a/src/mod_cgi.c
+++ b/src/mod_cgi.c
@@ -1092,11 +1092,10 @@ static int cgi_create_env(server *srv, connection *con, plugin_data *p, buffer *
 		/* exec the cgi */
 		execve(args[0], args, env.ptr);
 
-		/* log_error_write(srv, __FILE__, __LINE__, "sss", "CGI failed:", strerror(errno), args[0]); */
-
-		/* */
-		SEGFAULT();
-		break;
+		/* most log files may have been closed/redirected by this point,
+		 * though stderr might still point to lighttpd.breakage.log */
+		perror(args[0]);
+		_exit(1);
 	}
 	case -1:
 		/* error */


### PR DESCRIPTION
(replace SEGFAULT if execve() fails)

Reference:
  sloppy error handling in mod_cgi to affect binaries
  https://redmine.lighttpd.net/issues/2302