### PR TITLE
eval prev conditions in if-else before later cond

### DIFF
--- a/src/configfile-glue.c
+++ b/src/configfile-glue.c
@@ -264,7 +264,8 @@ static cond_result_t config_check_cond_nocache(server *srv, connection *con, dat
 		}
 
 		/* make sure prev is checked first */
-		config_check_cond_cached(srv, con, dc->prev);
+		if (config_check_cond_cached(srv, con, dc->prev) != COND_RESULT_FALSE) /* prev true or prev unset */
+			return con->cond_cache[dc->context_ndx].result; /* false if prev true; unset if prev unset */
 
 		/* one of prev set me to FALSE */
 		switch (con->cond_cache[dc->context_ndx].result) {


### PR DESCRIPTION
The first condition which evaluates true in any if-else... condition
chain short-circuits the chain, and any remaining conditions in the
chain are marked false.

Previous conditions in if-else condition chaining must be evaluatable
(to true or false) -- must not remain in unset (not yet evaluatable)
state -- prior to evaluating later conditions.  Since any true
condition short-circuits remaining conditions, all prev conditions
must be false prior to evaluating later conditions.

Reference:
  Semantics of else clause looks strange
  https://redmine.lighttpd.net/issues/2598