### PR TITLE
configparser.y: warn when dup keys in array merge

### DIFF
--- a/src/configparser.y
+++ b/src/configparser.y
@@ -91,7 +91,12 @@ data_unset *configparser_merge_data(data_unset *op1, const data_unset *op2) {
       for (i = 0; i < src->used; i ++) {
         du = (data_unset *)src->data[i];
         if (du) {
-          array_insert_unique(dst, du->copy(du));
+          if (du->is_index_key || buffer_is_empty(du->key) || !array_get_element(dst, du->key->ptr)) {
+            array_insert_unique(dst, du->copy(du));
+          } else {
+            fprintf(stderr, "WARNING: duplicated key '%s'; "
+                            "ignoring subsequent values\n", du->key->ptr);
+          }
         }
       }
       break;


### PR DESCRIPTION
prior behavior for merging arrays of arrays silently discarded
second array. New behavior issues warning.

prior behavior for merging arrays of integers silently discarded
second integer value. New behavior issues warning.

prior behavior for merging arrays of strings would join strings
with ", ", which might be appropriate for HTTP header list fields,
but not for config parsing.  New behavior issues warning.

This addresses the issue reported in:
  "weird outcome for duplicate alias map"
  https://redmine.lighttpd.net/issues/2685