### PR TITLE
[mod_webdav] allow Depth: Infinity lock on file

### DIFF
--- a/src/mod_webdav.c
+++ b/src/mod_webdav.c
@@ -2212,11 +2212,13 @@ propmatch_cleanup:
 				hdr_if = ds->value;
 			}
 
-			/* we don't support Depth: Infinity on locks */
+			/* we don't support Depth: Infinity on directories */
 			if (hdr_if == NULL && depth == -1) {
-				con->http_status = 409; /* Conflict */
+				if (0 == stat(con->physical.path->ptr, &st) && S_ISDIR(st.st_mode)) {
+					con->http_status = 409; /* Conflict */
 
-				return HANDLER_FINISHED;
+					return HANDLER_FINISHED;
+				}
 			}
 
 			if (1 == webdav_parse_chunkqueue(srv, con, p, con->request_content_queue, &xml)) {


### PR DESCRIPTION
(still not supporting Depth: Infinity on directories)

reference
  "Saving file to webdav mapped drive fails"
  https://redmine.lighttpd.net/issues/2296

patch by mstorsjo submitted as part of feature request
  https://redmine.lighttpd.net/issues/1953