### PR TITLE
set REDIRECT_STATUS to error_handler_saved_status

### DIFF
--- a/src/connections.c
+++ b/src/connections.c
@@ -873,6 +873,7 @@ int connection_reset(server *srv, connection *con) {
 
 	con->header_len = 0;
 	con->in_error_handler = 0;
+	con->error_handler_saved_status = 0;
 
 	config_setup_connection(srv, con);
 
@@ -1291,6 +1292,17 @@ int connection_state_machine(server *srv, connection *con) {
 						    (!buffer_string_is_empty(con->conf.error_handler) ||
 						     !buffer_string_is_empty(con->error_handler))) {
 							/* call error-handler */
+
+							/* set REDIRECT_STATUS to save current HTTP status code
+							 * for access by dynamic handlers
+							 * https://redmine.lighttpd.net/issues/1828 */
+							data_string *ds;
+							if (NULL == (ds = (data_string *)array_get_unused_element(con->environment, TYPE_STRING))) {
+								ds = data_string_init();
+							}
+							buffer_copy_string_len(ds->key, CONST_STR_LEN("REDIRECT_STATUS"));
+							buffer_append_int(ds->value, con->http_status);
+							array_insert_unique(con->environment, (data_unset *)ds);
 
 							con->error_handler_saved_status = con->http_status;
 							con->http_status = 0;

--- a/src/mod_cgi.c
+++ b/src/mod_cgi.c
@@ -961,12 +961,16 @@ static int cgi_create_env(server *srv, connection *con, plugin_data *p, buffer *
 		if (!buffer_string_is_empty(con->request.pathinfo)) {
 			cgi_env_add(&env, CONST_STR_LEN("PATH_INFO"), CONST_BUF_LEN(con->request.pathinfo));
 		}
-		cgi_env_add(&env, CONST_STR_LEN("REDIRECT_STATUS"), CONST_STR_LEN("200"));
 		if (!buffer_string_is_empty(con->uri.query)) {
 			cgi_env_add(&env, CONST_STR_LEN("QUERY_STRING"), CONST_BUF_LEN(con->uri.query));
 		}
 		if (!buffer_string_is_empty(con->request.orig_uri)) {
 			cgi_env_add(&env, CONST_STR_LEN("REQUEST_URI"), CONST_BUF_LEN(con->request.orig_uri));
+		}
+		/* set REDIRECT_STATUS for php compiled with --force-redirect
+		 * (if REDIRECT_STATUS has not already been set by error handler) */
+		if (0 == con->error_handler_saved_status) {
+			cgi_env_add(&env, CONST_STR_LEN("REDIRECT_STATUS"), CONST_STR_LEN("200"));
 		}
 
 

--- a/src/mod_fastcgi.c
+++ b/src/mod_fastcgi.c
@@ -1999,7 +1999,11 @@ static int fcgi_create_env(server *srv, handler_ctx *hctx, size_t request_id) {
 
 	s = get_http_method_name(con->request.http_method);
 	FCGI_ENV_ADD_CHECK(fcgi_env_add(p->fcgi_env, CONST_STR_LEN("REQUEST_METHOD"), s, strlen(s)),con)
-	FCGI_ENV_ADD_CHECK(fcgi_env_add(p->fcgi_env, CONST_STR_LEN("REDIRECT_STATUS"), CONST_STR_LEN("200")),con) /* if php is compiled with --force-redirect */
+	/* set REDIRECT_STATUS for php compiled with --force-redirect
+	 * (if REDIRECT_STATUS has not already been set by error handler) */
+	if (0 == con->error_handler_saved_status) {
+		FCGI_ENV_ADD_CHECK(fcgi_env_add(p->fcgi_env, CONST_STR_LEN("REDIRECT_STATUS"), CONST_STR_LEN("200")), con);
+	}
 	s = get_http_version_name(con->request.http_version);
 	FCGI_ENV_ADD_CHECK(fcgi_env_add(p->fcgi_env, CONST_STR_LEN("SERVER_PROTOCOL"), s, strlen(s)),con)
 

--- a/src/mod_scgi.c
+++ b/src/mod_scgi.c
@@ -1602,7 +1602,11 @@ static int scgi_create_env(server *srv, handler_ctx *hctx) {
 	s = get_http_method_name(con->request.http_method);
 	force_assert(s);
 	scgi_env_add(p->scgi_env, CONST_STR_LEN("REQUEST_METHOD"), s, strlen(s));
-	scgi_env_add(p->scgi_env, CONST_STR_LEN("REDIRECT_STATUS"), CONST_STR_LEN("200")); /* if php is compiled with --force-redirect */
+	/* set REDIRECT_STATUS for php compiled with --force-redirect
+	 * (if REDIRECT_STATUS has not already been set by error handler) */
+	if (0 == con->error_handler_saved_status) {
+		scgi_env_add(p->scgi_env, CONST_STR_LEN("REDIRECT_STATUS"), CONST_STR_LEN("200"));
+	}
 	s = get_http_version_name(con->request.http_version);
 	force_assert(s);
 	scgi_env_add(p->scgi_env, CONST_STR_LEN("SERVER_PROTOCOL"), s, strlen(s));

--- a/src/mod_ssi.c
+++ b/src/mod_ssi.c
@@ -277,8 +277,12 @@ static int build_ssi_cgi_vars(server *srv, connection *con, plugin_data *p) {
 	ssi_env_add(p->ssi_cgi_env, CONST_STRING("REQUEST_URI"), con->request.uri->ptr);
 	ssi_env_add(p->ssi_cgi_env, CONST_STRING("QUERY_STRING"), buffer_is_empty(con->uri.query) ? "" : con->uri.query->ptr);
 	ssi_env_add(p->ssi_cgi_env, CONST_STRING("REQUEST_METHOD"), get_http_method_name(con->request.http_method));
-	ssi_env_add(p->ssi_cgi_env, CONST_STRING("REDIRECT_STATUS"), "200");
 	ssi_env_add(p->ssi_cgi_env, CONST_STRING("SERVER_PROTOCOL"), get_http_version_name(con->request.http_version));
+	/* set REDIRECT_STATUS for php compiled with --force-redirect
+	 * (if REDIRECT_STATUS has not already been set by error handler) */
+	if (0 == con->error_handler_saved_status) {
+		ssi_env_add(p->ssi_cgi_env, CONST_STRING("REDIRECT_STATUS"), "200");
+	}
 
 	ssi_env_add_request_headers(srv, con, p);
 


### PR DESCRIPTION
set REDIRECT_STATUS to con->error_handler_saved_status in dynamic handlers for PHP compiled with --force-redirect.  Set to "200" if (0 == con->error_handler_saved_status)
(mod_cgi, mod_fastcgi, mod_scgi, mod_ssi)

FYI: setting REDIRECT_STATUS in con->environment allows access and manipulation by mod_magnet.

x-ref:
  "REDIRECT_STATUS == 200 on 404 redirect"
  https://redmine.lighttpd.net/issues/1828