### PR TITLE
server.error-handler new directive for error pages

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -81,6 +81,7 @@ NEWS
   * [core] open fd when appending file to cq (fixes #2655)
   * [config] server.listen-backlog option (fixes #1825, #2116)
   * [core] retry tempdirs on partial write, ENOSPC (fixes #2588)
+  * [core] compile with upcoming openssl 1.1.0 release (fixes #2727)
 
 - 1.4.39 - 2016-01-02
   * [core] fix memset_s call (fixes #2698)

--- a/doc/config/conf.d/mime.conf
+++ b/doc/config/conf.d/mime.conf
@@ -8,8 +8,19 @@
 ## https://redmine.lighttpd.net/projects/lighttpd/wiki/Mimetype_assignDetails
 
 ##
-## Use the "Content-Type" extended file attribute to obtain mime type if
-## possible
+## mimetype.xattr-name
+## Set the extended file attribute name used to obtain mime type
+## (must also set mimetype.use-xattr = "enable")
+##
+## Default value is "Content-Type"
+##
+## freedesktop.org Shared MIME-info Database specification suggests
+## user-defined value ("user.mime_type") as name for extended file attribute
+#mimetype.xattr-name = "user.mime_type"
+
+##
+## Use extended attribute named in mimetype.xattr-name (default "Content-Type")
+## to obtain mime type if possible
 ##
 ## Disabled by default
 ##

--- a/doc/config/conf.d/ssi.conf
+++ b/doc/config/conf.d/ssi.conf
@@ -39,6 +39,10 @@ ssi.extension              = ( ".shtml" )
 ##
 ## Disabled by default.
 ##
+## For further explanation of conditional requests, please see
+## Hypertext Transfer Protocol (HTTP/1.1): Conditional Requests
+## https://tools.ietf.org/html/rfc7232
+##
 #ssi.conditional-requests = "enable"
 
 ##

--- a/doc/config/lighttpd.conf
+++ b/doc/config/lighttpd.conf
@@ -365,6 +365,12 @@ $HTTP["url"] =~ "\.pdf$" {
 static-file.exclude-extensions = ( ".php", ".pl", ".fcgi", ".scgi" )
 
 ##
+## error-handler for all status 400-599
+##
+#server.error-handler       = "/error-handler.html"
+#server.error-handler       = "/error-handler.php"
+
+##
 ## error-handler for status 404
 ##
 #server.error-handler-404   = "/error-handler.html"

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -92,184 +92,187 @@ if NO_RDYNAMIC
 # if the linker doesn't allow referencing symbols of the binary
 # we have to put everything into a shared-lib and link it into
 # everything
+common_ldflags = -avoid-version -no-undefined
 lib_LTLIBRARIES += liblightcomp.la
 liblightcomp_la_SOURCES=$(common_src)
 liblightcomp_la_CFLAGS=$(AM_CFLAGS) $(LIBEV_CFLAGS)
-liblightcomp_la_LDFLAGS = -avoid-version -no-undefined
+liblightcomp_la_LDFLAGS = $(common_ldflags)
 liblightcomp_la_LIBADD = $(PCRE_LIB) $(SSL_LIB) $(FAM_LIBS) $(LIBEV_LIBS)
 common_libadd = liblightcomp.la
 else
 src += $(common_src)
+common_ldflags = -avoid-version
 common_libadd =
 endif
+common_module_ldflags = -module -export-dynamic $(common_ldflags)
 
 lib_LTLIBRARIES += mod_flv_streaming.la
 mod_flv_streaming_la_SOURCES = mod_flv_streaming.c
-mod_flv_streaming_la_LDFLAGS = -module -export-dynamic -avoid-version
+mod_flv_streaming_la_LDFLAGS = $(common_module_ldflags)
 mod_flv_streaming_la_LIBADD = $(common_libadd)
 
 lib_LTLIBRARIES += mod_evasive.la
 mod_evasive_la_SOURCES = mod_evasive.c
-mod_evasive_la_LDFLAGS = -module -export-dynamic -avoid-version
+mod_evasive_la_LDFLAGS = $(common_module_ldflags)
 mod_evasive_la_LIBADD = $(common_libadd)
 
 lib_LTLIBRARIES += mod_webdav.la
 mod_webdav_la_SOURCES = mod_webdav.c
 mod_webdav_la_CFLAGS = $(AM_CFLAGS) $(XML_CFLAGS) $(SQLITE_CFLAGS) 
-mod_webdav_la_LDFLAGS = -module -export-dynamic -avoid-version
+mod_webdav_la_LDFLAGS = $(common_module_ldflags)
 mod_webdav_la_LIBADD = $(common_libadd) $(XML_LIBS) $(SQLITE_LIBS) $(UUID_LIBS)
 
 lib_LTLIBRARIES += mod_magnet.la
 mod_magnet_la_SOURCES = mod_magnet.c mod_magnet_cache.c
 mod_magnet_la_CFLAGS = $(AM_CFLAGS) $(LUA_CFLAGS)
-mod_magnet_la_LDFLAGS = -module -export-dynamic -avoid-version
+mod_magnet_la_LDFLAGS = $(common_module_ldflags)
 mod_magnet_la_LIBADD = $(common_libadd) $(LUA_LIBS) -lm
 
 lib_LTLIBRARIES += mod_cml.la
 mod_cml_la_SOURCES = mod_cml.c mod_cml_lua.c mod_cml_funcs.c
 mod_cml_la_CFLAGS = $(AM_CFLAGS) $(LUA_CFLAGS)
-mod_cml_la_LDFLAGS = -module -export-dynamic -avoid-version
+mod_cml_la_LDFLAGS = $(common_module_ldflags)
 mod_cml_la_LIBADD = $(MEMCACHED_LIB) $(common_libadd) $(LUA_LIBS) -lm
 
 lib_LTLIBRARIES += mod_trigger_b4_dl.la
 mod_trigger_b4_dl_la_SOURCES = mod_trigger_b4_dl.c
-mod_trigger_b4_dl_la_LDFLAGS = -module -export-dynamic -avoid-version
+mod_trigger_b4_dl_la_LDFLAGS = $(common_module_ldflags)
 mod_trigger_b4_dl_la_LIBADD = $(GDBM_LIB) $(MEMCACHED_LIB) $(PCRE_LIB) $(common_libadd)
 
 lib_LTLIBRARIES += mod_mysql_vhost.la
 mod_mysql_vhost_la_SOURCES = mod_mysql_vhost.c
-mod_mysql_vhost_la_LDFLAGS = -module -export-dynamic -avoid-version
+mod_mysql_vhost_la_LDFLAGS = $(common_module_ldflags)
 mod_mysql_vhost_la_LIBADD = $(MYSQL_LIBS) $(common_libadd)
 mod_mysql_vhost_la_CPPFLAGS = $(MYSQL_INCLUDE)
 
 lib_LTLIBRARIES += mod_cgi.la
 mod_cgi_la_SOURCES = mod_cgi.c
-mod_cgi_la_LDFLAGS = -module -export-dynamic -avoid-version
+mod_cgi_la_LDFLAGS = $(common_module_ldflags)
 mod_cgi_la_LIBADD = $(common_libadd)
 
 lib_LTLIBRARIES += mod_scgi.la
 mod_scgi_la_SOURCES = mod_scgi.c
-mod_scgi_la_LDFLAGS = -module -export-dynamic -avoid-version
+mod_scgi_la_LDFLAGS = $(common_module_ldflags)
 mod_scgi_la_LIBADD = $(common_libadd)
 
 lib_LTLIBRARIES += mod_staticfile.la
 mod_staticfile_la_SOURCES = mod_staticfile.c
-mod_staticfile_la_LDFLAGS = -module -export-dynamic -avoid-version
+mod_staticfile_la_LDFLAGS = $(common_module_ldflags)
 mod_staticfile_la_LIBADD = $(common_libadd)
 
 lib_LTLIBRARIES += mod_dirlisting.la
 mod_dirlisting_la_SOURCES = mod_dirlisting.c
-mod_dirlisting_la_LDFLAGS = -module -export-dynamic -avoid-version
+mod_dirlisting_la_LDFLAGS = $(common_module_ldflags)
 mod_dirlisting_la_LIBADD = $(common_libadd) $(PCRE_LIB)
 
 lib_LTLIBRARIES += mod_indexfile.la
 mod_indexfile_la_SOURCES = mod_indexfile.c
-mod_indexfile_la_LDFLAGS = -module -export-dynamic -avoid-version
+mod_indexfile_la_LDFLAGS = $(common_module_ldflags)
 mod_indexfile_la_LIBADD = $(common_libadd)
 
 lib_LTLIBRARIES += mod_setenv.la
 mod_setenv_la_SOURCES = mod_setenv.c
-mod_setenv_la_LDFLAGS = -module -export-dynamic -avoid-version
+mod_setenv_la_LDFLAGS = $(common_module_ldflags)
 mod_setenv_la_LIBADD = $(common_libadd)
 
 lib_LTLIBRARIES += mod_alias.la
 mod_alias_la_SOURCES = mod_alias.c
-mod_alias_la_LDFLAGS = -module -export-dynamic -avoid-version
+mod_alias_la_LDFLAGS = $(common_module_ldflags)
 mod_alias_la_LIBADD = $(common_libadd)
 
 lib_LTLIBRARIES += mod_userdir.la
 mod_userdir_la_SOURCES = mod_userdir.c
-mod_userdir_la_LDFLAGS = -module -export-dynamic -avoid-version
+mod_userdir_la_LDFLAGS = $(common_module_ldflags)
 mod_userdir_la_LIBADD = $(common_libadd)
 
 lib_LTLIBRARIES += mod_rrdtool.la
 mod_rrdtool_la_SOURCES = mod_rrdtool.c
-mod_rrdtool_la_LDFLAGS = -module -export-dynamic -avoid-version
+mod_rrdtool_la_LDFLAGS = $(common_module_ldflags)
 mod_rrdtool_la_LIBADD = $(common_libadd)
 
 lib_LTLIBRARIES += mod_usertrack.la
 mod_usertrack_la_SOURCES = mod_usertrack.c
-mod_usertrack_la_LDFLAGS = -module -export-dynamic -avoid-version
+mod_usertrack_la_LDFLAGS = $(common_module_ldflags)
 mod_usertrack_la_LIBADD = $(common_libadd)
 
 lib_LTLIBRARIES += mod_proxy.la
 mod_proxy_la_SOURCES = mod_proxy.c
-mod_proxy_la_LDFLAGS = -module -export-dynamic -avoid-version
+mod_proxy_la_LDFLAGS = $(common_module_ldflags)
 mod_proxy_la_LIBADD = $(common_libadd)
 
 lib_LTLIBRARIES += mod_ssi.la
 mod_ssi_la_SOURCES = mod_ssi_exprparser.c mod_ssi_expr.c mod_ssi.c
-mod_ssi_la_LDFLAGS = -module -export-dynamic -avoid-version
+mod_ssi_la_LDFLAGS = $(common_module_ldflags)
 mod_ssi_la_LIBADD = $(common_libadd) $(PCRE_LIB)
 
 lib_LTLIBRARIES += mod_secdownload.la
 mod_secdownload_la_SOURCES = mod_secdownload.c
-mod_secdownload_la_LDFLAGS = -module -export-dynamic -avoid-version
+mod_secdownload_la_LDFLAGS = $(common_module_ldflags)
 mod_secdownload_la_LIBADD = $(common_libadd)
 
 #lib_LTLIBRARIES += mod_httptls.la
 #mod_httptls_la_SOURCES = mod_httptls.c
-#mod_httptls_la_LDFLAGS = -module -export-dynamic -avoid-version
+#mod_httptls_la_LDFLAGS = $(common_module_ldflags)
 #mod_httptls_la_LIBADD = $(common_libadd)
 
 lib_LTLIBRARIES += mod_expire.la
 mod_expire_la_SOURCES = mod_expire.c
-mod_expire_la_LDFLAGS = -module -export-dynamic -avoid-version
+mod_expire_la_LDFLAGS = $(common_module_ldflags)
 mod_expire_la_LIBADD = $(common_libadd)
 
 lib_LTLIBRARIES += mod_evhost.la
 mod_evhost_la_SOURCES = mod_evhost.c
-mod_evhost_la_LDFLAGS = -module -export-dynamic -avoid-version
+mod_evhost_la_LDFLAGS = $(common_module_ldflags)
 mod_evhost_la_LIBADD = $(common_libadd)
 
 lib_LTLIBRARIES += mod_simple_vhost.la
 mod_simple_vhost_la_SOURCES = mod_simple_vhost.c
-mod_simple_vhost_la_LDFLAGS = -module -export-dynamic -avoid-version
+mod_simple_vhost_la_LDFLAGS = $(common_module_ldflags)
 mod_simple_vhost_la_LIBADD = $(common_libadd)
 
 lib_LTLIBRARIES += mod_fastcgi.la
 mod_fastcgi_la_SOURCES = mod_fastcgi.c
-mod_fastcgi_la_LDFLAGS = -module -export-dynamic -avoid-version
+mod_fastcgi_la_LDFLAGS = $(common_module_ldflags)
 mod_fastcgi_la_LIBADD = $(common_libadd)
 
 lib_LTLIBRARIES += mod_extforward.la
 mod_extforward_la_SOURCES = mod_extforward.c
-mod_extforward_la_LDFLAGS = -module -export-dynamic -avoid-version
+mod_extforward_la_LDFLAGS = $(common_module_ldflags)
 mod_extforward_la_LIBADD = $(common_libadd)
 
 lib_LTLIBRARIES += mod_access.la
 mod_access_la_SOURCES = mod_access.c
-mod_access_la_LDFLAGS = -module -export-dynamic -avoid-version
+mod_access_la_LDFLAGS = $(common_module_ldflags)
 mod_access_la_LIBADD = $(common_libadd)
 
 lib_LTLIBRARIES += mod_compress.la
 mod_compress_la_SOURCES = mod_compress.c
-mod_compress_la_LDFLAGS = -module -export-dynamic -avoid-version
+mod_compress_la_LDFLAGS = $(common_module_ldflags)
 mod_compress_la_LIBADD = $(Z_LIB) $(BZ_LIB) $(common_libadd)
 
 lib_LTLIBRARIES += mod_auth.la
 mod_auth_la_SOURCES = mod_auth.c http_auth.c
-mod_auth_la_LDFLAGS = -module -export-dynamic -avoid-version
+mod_auth_la_LDFLAGS = $(common_module_ldflags)
 mod_auth_la_LIBADD = $(CRYPT_LIB) $(SSL_LIB) $(LDAP_LIB) $(LBER_LIB) $(common_libadd)
 
 lib_LTLIBRARIES += mod_rewrite.la
 mod_rewrite_la_SOURCES = mod_rewrite.c
-mod_rewrite_la_LDFLAGS = -module -export-dynamic -avoid-version
+mod_rewrite_la_LDFLAGS = $(common_module_ldflags)
 mod_rewrite_la_LIBADD = $(PCRE_LIB) $(common_libadd)
 
 lib_LTLIBRARIES += mod_redirect.la
 mod_redirect_la_SOURCES = mod_redirect.c
-mod_redirect_la_LDFLAGS = -module -export-dynamic -avoid-version
+mod_redirect_la_LDFLAGS = $(common_module_ldflags)
 mod_redirect_la_LIBADD = $(PCRE_LIB) $(common_libadd)
 
 lib_LTLIBRARIES += mod_status.la
 mod_status_la_SOURCES = mod_status.c
-mod_status_la_LDFLAGS = -module -export-dynamic -avoid-version
+mod_status_la_LDFLAGS = $(common_module_ldflags)
 mod_status_la_LIBADD = $(common_libadd)
 
 lib_LTLIBRARIES += mod_accesslog.la
 mod_accesslog_la_SOURCES = mod_accesslog.c
-mod_accesslog_la_LDFLAGS = -module -export-dynamic -avoid-version
+mod_accesslog_la_LDFLAGS = $(common_module_ldflags)
 mod_accesslog_la_LIBADD = $(common_libadd)
 
 

--- a/src/base.h
+++ b/src/base.h
@@ -245,6 +245,7 @@ typedef struct {
 	buffer *document_root;
 	buffer *server_name;
 	buffer *error_handler;
+	buffer *error_handler_404;
 	buffer *server_tag;
 	buffer *dirlist_encoding;
 	buffer *errorfile_prefix;
@@ -447,6 +448,7 @@ typedef struct {
 
 	/* error-handler */
 	int error_handler_saved_status;
+	http_method_t error_handler_saved_method;
 
 	struct server_socket *srv_socket;   /* reference to the server-socket */
 

--- a/src/base.h
+++ b/src/base.h
@@ -446,9 +446,7 @@ typedef struct {
 	buffer *server_name;
 
 	/* error-handler */
-	buffer *error_handler;
 	int error_handler_saved_status;
-	int in_error_handler;
 
 	struct server_socket *srv_socket;   /* reference to the server-socket */
 

--- a/src/configfile.c
+++ b/src/configfile.c
@@ -52,7 +52,7 @@ static int config_insert(server *srv) {
 
 		{ "server.max-read-idle",              NULL, T_CONFIG_SHORT,   T_CONFIG_SCOPE_CONNECTION }, /* 20 */
 		{ "server.max-write-idle",             NULL, T_CONFIG_SHORT,   T_CONFIG_SCOPE_CONNECTION }, /* 21 */
-		{ "server.error-handler-404",          NULL, T_CONFIG_STRING,  T_CONFIG_SCOPE_CONNECTION }, /* 22 */
+		{ "server.error-handler",              NULL, T_CONFIG_STRING,  T_CONFIG_SCOPE_CONNECTION }, /* 22 */
 		{ "server.max-fds",                    NULL, T_CONFIG_SHORT,   T_CONFIG_SCOPE_SERVER     }, /* 23 */
 #ifdef HAVE_LSTAT
 		{ "server.follow-symlink",             NULL, T_CONFIG_BOOLEAN, T_CONFIG_SCOPE_CONNECTION }, /* 24 */
@@ -112,6 +112,7 @@ static int config_insert(server *srv) {
 		{ "server.upload-temp-file-size",      NULL, T_CONFIG_INT,     T_CONFIG_SCOPE_SERVER     }, /* 68 */
 		{ "mimetype.xattr-name",               NULL, T_CONFIG_STRING,  T_CONFIG_SCOPE_SERVER     }, /* 69 */
 		{ "server.listen-backlog",             NULL, T_CONFIG_INT,     T_CONFIG_SCOPE_CONNECTION }, /* 70 */
+		{ "server.error-handler-404",          NULL, T_CONFIG_STRING,  T_CONFIG_SCOPE_CONNECTION }, /* 71 */
 
 		{ "server.host",
 			"use server.bind instead",
@@ -193,6 +194,7 @@ static int config_insert(server *srv) {
 		s->ssl_pemfile   = buffer_init();
 		s->ssl_ca_file   = buffer_init();
 		s->error_handler = buffer_init();
+		s->error_handler_404 = buffer_init();
 		s->server_tag    = buffer_init();
 		s->ssl_cipher_list = buffer_init();
 		s->ssl_dh_file   = buffer_init();
@@ -288,6 +290,7 @@ static int config_insert(server *srv) {
 		cv[66].destination = &(s->ssl_honor_cipher_order);
 		cv[67].destination = &(s->ssl_empty_fragments);
 		cv[70].destination = &(s->listen_backlog);
+		cv[71].destination = s->error_handler_404;
 
 		srv->config_storage[i] = s;
 
@@ -336,6 +339,7 @@ int config_setup_connection(server *srv, connection *con) {
 	PATCH(max_write_idle);
 	PATCH(use_xattr);
 	PATCH(error_handler);
+	PATCH(error_handler_404);
 	PATCH(errorfile_prefix);
 #ifdef HAVE_LSTAT
 	PATCH(follow_symlink);
@@ -410,8 +414,10 @@ int config_patch_connection(server *srv, connection *con) {
 				PATCH(document_root);
 			} else if (buffer_is_equal_string(du->key, CONST_STR_LEN("server.range-requests"))) {
 				PATCH(range_requests);
-			} else if (buffer_is_equal_string(du->key, CONST_STR_LEN("server.error-handler-404"))) {
+			} else if (buffer_is_equal_string(du->key, CONST_STR_LEN("server.error-handler"))) {
 				PATCH(error_handler);
+			} else if (buffer_is_equal_string(du->key, CONST_STR_LEN("server.error-handler-404"))) {
+				PATCH(error_handler_404);
 			} else if (buffer_is_equal_string(du->key, CONST_STR_LEN("server.errorfile-prefix"))) {
 				PATCH(errorfile_prefix);
 			} else if (buffer_is_equal_string(du->key, CONST_STR_LEN("mimetype.assign"))) {

--- a/src/connections-glue.c
+++ b/src/connections-glue.c
@@ -180,9 +180,15 @@ static int connection_handle_read_ssl(server *srv, connection *con) {
 			while((ssl_err = ERR_get_error())) {
 				switch (ERR_GET_REASON(ssl_err)) {
 				case SSL_R_SSL_HANDSHAKE_FAILURE:
+			      #ifdef SSL_R_TLSV1_ALERT_UNKNOWN_CA
 				case SSL_R_TLSV1_ALERT_UNKNOWN_CA:
+			      #endif
+			      #ifdef SSL_R_SSLV3_ALERT_CERTIFICATE_UNKNOWN
 				case SSL_R_SSLV3_ALERT_CERTIFICATE_UNKNOWN:
+			      #endif
+			      #ifdef SSL_R_SSLV3_ALERT_BAD_CERTIFICATE
 				case SSL_R_SSLV3_ALERT_BAD_CERTIFICATE:
+			      #endif
 					if (!con->conf.log_ssl_noise) continue;
 					break;
 				default:

--- a/src/connections.c
+++ b/src/connections.c
@@ -632,6 +632,8 @@ int connection_reset(server *srv, connection *con) {
 
 	con->header_len = 0;
 	con->error_handler_saved_status = 0;
+	/*con->error_handler_saved_method = HTTP_METHOD_UNSET;*/
+	/*(error_handler_saved_method value is not valid unless error_handler_saved_status is set)*/
 
 	config_setup_connection(srv, con);
 
@@ -1021,19 +1023,30 @@ int connection_state_machine(server *srv, connection *con) {
 
 			switch (r = http_response_prepare(srv, con)) {
 			case HANDLER_FINISHED:
+				if (con->error_handler_saved_status > 0) {
+					con->request.http_method = con->error_handler_saved_method;
+				}
 				if (con->mode == DIRECT) {
 					if (con->error_handler_saved_status) {
-						if (con->http_status == 404 || con->http_status == 403) {
-							/* error-handler-404 is a 404 */
+						if (con->error_handler_saved_status > 0) {
 							con->http_status = con->error_handler_saved_status;
+						} else if (con->http_status == 404 || con->http_status == 403) {
+							/* error-handler-404 is a 404 */
+							con->http_status = -con->error_handler_saved_status;
 						} else {
 							/* error-handler-404 is back and has generated content */
 							/* if Status: was set, take it otherwise use 200 */
 						}
-					} else if (con->http_status == 404 || con->http_status == 403) {
-						/* 404 error-handler */
-
+					} else if (con->http_status >= 400) {
+						buffer *error_handler = NULL;
 						if (!buffer_string_is_empty(con->conf.error_handler)) {
+							error_handler = con->conf.error_handler;
+						} else if ((con->http_status == 404 || con->http_status == 403)
+							   && !buffer_string_is_empty(con->conf.error_handler_404)) {
+							error_handler = con->conf.error_handler_404;
+						}
+
+						if (error_handler) {
 							/* call error-handler */
 
 							/* set REDIRECT_STATUS to save current HTTP status code
@@ -1047,10 +1060,40 @@ int connection_state_machine(server *srv, connection *con) {
 							buffer_append_int(ds->value, con->http_status);
 							array_insert_unique(con->environment, (data_unset *)ds);
 
-							con->error_handler_saved_status = con->http_status;
+							if (error_handler == con->conf.error_handler) {
+								plugins_call_connection_reset(srv, con);
+
+								if (con->request.content_length) {
+									if ((off_t)con->request.content_length != chunkqueue_length(con->request_content_queue)) {
+										con->keep_alive = 0;
+									}
+									con->request.content_length = 0;
+									chunkqueue_reset(con->request_content_queue);
+								}
+
+								con->is_writable = 1;
+								con->file_finished = 0;
+								con->file_started = 0;
+								con->got_response = 0;
+								con->parsed_response = 0;
+								con->response.keep_alive = 0;
+								con->response.content_length = -1;
+								con->response.transfer_encoding = 0;
+								array_reset(con->response.headers);
+								chunkqueue_reset(con->write_queue);
+
+								array_set_key_value(con->environment, CONST_STR_LEN("REDIRECT_URI"), CONST_BUF_LEN(con->request.orig_uri));
+								con->error_handler_saved_status = con->http_status;
+								con->error_handler_saved_method = con->request.http_method;
+
+								con->request.http_method = HTTP_METHOD_GET;
+							} else { /*(preserve behavior for server.error-handler-404)*/
+								array_set_key_value(con->environment, CONST_STR_LEN("REDIRECT_URI"), CONST_BUF_LEN(error_handler));
+								con->error_handler_saved_status = -con->http_status; /*(negative to flag old behavior)*/
+							}
 							con->http_status = 0;
 
-							buffer_copy_buffer(con->request.uri, con->conf.error_handler);
+							buffer_copy_buffer(con->request.uri, error_handler);
 							buffer_reset(con->physical.path);
 							connection_handle_errdoc_init(con);
 

--- a/src/connections.c
+++ b/src/connections.c
@@ -635,6 +635,7 @@ int connection_reset(server *srv, connection *con) {
 
 	con->header_len = 0;
 	con->in_error_handler = 0;
+	con->error_handler_saved_status = 0;
 
 	config_setup_connection(srv, con);
 
@@ -1033,6 +1034,17 @@ int connection_state_machine(server *srv, connection *con) {
 						    (!buffer_string_is_empty(con->conf.error_handler) ||
 						     !buffer_string_is_empty(con->error_handler))) {
 							/* call error-handler */
+
+							/* set REDIRECT_STATUS to save current HTTP status code
+							 * for access by dynamic handlers
+							 * https://redmine.lighttpd.net/issues/1828 */
+							data_string *ds;
+							if (NULL == (ds = (data_string *)array_get_unused_element(con->environment, TYPE_STRING))) {
+								ds = data_string_init();
+							}
+							buffer_copy_string_len(ds->key, CONST_STR_LEN("REDIRECT_STATUS"));
+							buffer_append_int(ds->value, con->http_status);
+							array_insert_unique(con->environment, (data_unset *)ds);
 
 							con->error_handler_saved_status = con->http_status;
 							con->http_status = 0;

--- a/src/http-header-glue.c
+++ b/src/http-header-glue.c
@@ -140,7 +140,8 @@ int http_response_redirect_to_directory(server *srv, connection *con) {
 
 		our_addr_len = sizeof(our_addr);
 
-		if (-1 == getsockname(con->fd, &(our_addr.plain), &our_addr_len)) {
+		if (-1 == getsockname(con->fd, (struct sockaddr *)&our_addr, &our_addr_len)
+		    || our_addr_len > sizeof(our_addr)) {
 			con->http_status = 500;
 
 			log_error_write(srv, __FILE__, __LINE__, "ss",

--- a/src/mod_cgi.c
+++ b/src/mod_cgi.c
@@ -1078,7 +1078,6 @@ static int cgi_create_env(server *srv, connection *con, plugin_data *p, handler_
 		if (!buffer_string_is_empty(con->request.pathinfo)) {
 			cgi_env_add(&env, CONST_STR_LEN("PATH_INFO"), CONST_BUF_LEN(con->request.pathinfo));
 		}
-		cgi_env_add(&env, CONST_STR_LEN("REDIRECT_STATUS"), CONST_STR_LEN("200"));
 		if (!buffer_string_is_empty(con->uri.query)) {
 			cgi_env_add(&env, CONST_STR_LEN("QUERY_STRING"), CONST_BUF_LEN(con->uri.query));
 		} else {
@@ -1086,6 +1085,11 @@ static int cgi_create_env(server *srv, connection *con, plugin_data *p, handler_
 		}
 		if (!buffer_string_is_empty(con->request.orig_uri)) {
 			cgi_env_add(&env, CONST_STR_LEN("REQUEST_URI"), CONST_BUF_LEN(con->request.orig_uri));
+		}
+		/* set REDIRECT_STATUS for php compiled with --force-redirect
+		 * (if REDIRECT_STATUS has not already been set by error handler) */
+		if (0 == con->error_handler_saved_status) {
+			cgi_env_add(&env, CONST_STR_LEN("REDIRECT_STATUS"), CONST_STR_LEN("200"));
 		}
 
 

--- a/src/mod_cgi.c
+++ b/src/mod_cgi.c
@@ -1083,7 +1083,9 @@ static int cgi_create_env(server *srv, connection *con, plugin_data *p, handler_
 		} else {
 			cgi_env_add(&env, CONST_STR_LEN("QUERY_STRING"), CONST_STR_LEN(""));
 		}
-		if (!buffer_string_is_empty(con->request.orig_uri)) {
+		if (con->error_handler_saved_status >= 0) {
+			cgi_env_add(&env, CONST_STR_LEN("REQUEST_URI"), CONST_BUF_LEN(con->request.uri));
+		} else {
 			cgi_env_add(&env, CONST_STR_LEN("REQUEST_URI"), CONST_BUF_LEN(con->request.orig_uri));
 		}
 		/* set REDIRECT_STATUS for php compiled with --force-redirect

--- a/src/mod_fastcgi.c
+++ b/src/mod_fastcgi.c
@@ -1033,11 +1033,12 @@ static int fcgi_spawn_connection(server *srv,
 					}
 				}
 			} else {
-				for (i = 0; environ[i]; i++) {
+				char ** const e = environ;
+				for (i = 0; e[i]; ++i) {
 					char *eq;
 
-					if (NULL != (eq = strchr(environ[i], '='))) {
-						env_add(&env, environ[i], eq - environ[i], eq+1, strlen(eq+1));
+					if (NULL != (eq = strchr(e[i], '='))) {
+						env_add(&env, e[i], eq - e[i], eq+1, strlen(eq+1));
 					}
 				}
 			}
@@ -1926,7 +1927,8 @@ static int fcgi_create_env(server *srv, handler_ctx *hctx, size_t request_id) {
 	/* get the server-side of the connection to the client */
 	our_addr_len = sizeof(our_addr);
 
-	if (-1 == getsockname(con->fd, &(our_addr.plain), &our_addr_len)) {
+	if (-1 == getsockname(con->fd, (struct sockaddr *)&our_addr, &our_addr_len)
+	    || our_addr_len > sizeof(our_addr)) {
 		s = inet_ntop_cache_get_ip(srv, &(srv_sock->addr));
 	} else {
 		s = inet_ntop_cache_get_ip(srv, &(our_addr));

--- a/src/mod_fastcgi.c
+++ b/src/mod_fastcgi.c
@@ -1227,7 +1227,7 @@ SETDEFAULTS_FUNC(mod_fastcgi_set_defaults) {
 
 			if (du->type != TYPE_ARRAY) {
 				log_error_write(srv, __FILE__, __LINE__, "sss",
-						"unexpected type for key: ", "fastcgi.server", "array of strings");
+						"unexpected type for key: ", "fastcgi.server", "expected ( \"ext\" => ( \"backend-label\" => ( \"key\" => \"value\" )))");
 
 				goto error;
 			}
@@ -1245,7 +1245,7 @@ SETDEFAULTS_FUNC(mod_fastcgi_set_defaults) {
 				if (da->value->data[j]->type != TYPE_ARRAY) {
 					log_error_write(srv, __FILE__, __LINE__, "sssbs",
 							"unexpected type for key: ", "fastcgi.server",
-							"[", da->value->data[j]->key, "](string)");
+							"[", da->value->data[j]->key, "](string); expected ( \"ext\" => ( \"backend-label\" => ( \"key\" => \"value\" )))");
 
 					goto error;
 				}
@@ -1294,7 +1294,7 @@ SETDEFAULTS_FUNC(mod_fastcgi_set_defaults) {
 						log_error_write(srv, __FILE__, __LINE__, "ssSBS",
 								"unexpected type for key:",
 								"fastcgi.server",
-								"[", da_host->key, "](string)");
+								"[", da_host->key, "](string); expected ( \"ext\" => ( \"backend-label\" => ( \"key\" => \"value\" )))");
 
 						goto error;
 					}

--- a/src/mod_fastcgi.c
+++ b/src/mod_fastcgi.c
@@ -2056,7 +2056,11 @@ static int fcgi_create_env(server *srv, handler_ctx *hctx, size_t request_id) {
 	s = get_http_method_name(con->request.http_method);
 	force_assert(s);
 	FCGI_ENV_ADD_CHECK(fcgi_env_add(p->fcgi_env, CONST_STR_LEN("REQUEST_METHOD"), s, strlen(s)),con)
-	FCGI_ENV_ADD_CHECK(fcgi_env_add(p->fcgi_env, CONST_STR_LEN("REDIRECT_STATUS"), CONST_STR_LEN("200")),con) /* if php is compiled with --force-redirect */
+	/* set REDIRECT_STATUS for php compiled with --force-redirect
+	 * (if REDIRECT_STATUS has not already been set by error handler) */
+	if (0 == con->error_handler_saved_status) {
+		FCGI_ENV_ADD_CHECK(fcgi_env_add(p->fcgi_env, CONST_STR_LEN("REDIRECT_STATUS"), CONST_STR_LEN("200")), con);
+	}
 	s = get_http_version_name(con->request.http_version);
 	force_assert(s);
 	FCGI_ENV_ADD_CHECK(fcgi_env_add(p->fcgi_env, CONST_STR_LEN("SERVER_PROTOCOL"), s, strlen(s)),con)

--- a/src/mod_magnet.c
+++ b/src/mod_magnet.c
@@ -1015,6 +1015,12 @@ static handler_t magnet_attract(server *srv, connection *con, plugin_data *p, bu
 
 			result = HANDLER_FINISHED;
 		} else if (MAGNET_RESTART_REQUEST == lua_return_value) {
+			if (!buffer_is_equal(con->request.uri, con->request.orig_uri)
+			    && !array_get_element(con->environment, "REDIRECT_URI")) {
+				array_set_key_value(con->environment,
+						    CONST_STR_LEN("REDIRECT_URI"),
+						    CONST_BUF_LEN(con->request.orig_uri));
+			}
 			result = HANDLER_COMEBACK;
 		}
 

--- a/src/mod_proxy.c
+++ b/src/mod_proxy.c
@@ -232,7 +232,7 @@ SETDEFAULTS_FUNC(mod_proxy_set_defaults) {
 
 			if (du->type != TYPE_ARRAY) {
 				log_error_write(srv, __FILE__, __LINE__, "sss",
-						"unexpected type for key: ", "proxy.server", "array of strings");
+						"unexpected type for key: ", "proxy.server", "expected ( \"ext\" => ( \"backend-label\" => ( \"key\" => \"value\" )))");
 
 				return HANDLER_ERROR;
 			}
@@ -249,7 +249,7 @@ SETDEFAULTS_FUNC(mod_proxy_set_defaults) {
 				if (da_ext->type != TYPE_ARRAY) {
 					log_error_write(srv, __FILE__, __LINE__, "sssbs",
 							"unexpected type for key: ", "proxy.server",
-							"[", da->value->data[j]->key, "](string)");
+							"[", da->value->data[j]->key, "](string); expected ( \"ext\" => ( \"backend-label\" => ( \"key\" => \"value\" )))");
 
 					return HANDLER_ERROR;
 				}
@@ -278,7 +278,7 @@ SETDEFAULTS_FUNC(mod_proxy_set_defaults) {
 						log_error_write(srv, __FILE__, __LINE__, "ssSBS",
 								"unexpected type for key:",
 								"proxy.server",
-								"[", da_ext->value->data[n]->key, "](string)");
+								"[", da_ext->value->data[n]->key, "](string); expected ( \"ext\" => ( \"backend-label\" => ( \"key\" => \"value\" )))");
 
 						return HANDLER_ERROR;
 					}

--- a/src/mod_rewrite.c
+++ b/src/mod_rewrite.c
@@ -444,6 +444,13 @@ static handler_t process_rewrite_rules(server *srv, connection *con, plugin_data
 
 			if (rule->once) hctx->state = REWRITE_STATE_FINISHED;
 
+			if (!buffer_is_equal(con->request.uri, con->request.orig_uri)
+			    && !array_get_element(con->environment, "REDIRECT_URI")) {
+				array_set_key_value(con->environment,
+						    CONST_STR_LEN("REDIRECT_URI"),
+						    CONST_BUF_LEN(con->request.orig_uri));
+			}
+
 			return HANDLER_COMEBACK;
 		}
 #undef N

--- a/src/mod_scgi.c
+++ b/src/mod_scgi.c
@@ -1648,9 +1648,10 @@ static int scgi_create_env(server *srv, handler_ctx *hctx) {
 		scgi_env_add(p->scgi_env, CONST_STR_LEN("SCRIPT_FILENAME"), CONST_BUF_LEN(p->path));
 		scgi_env_add(p->scgi_env, CONST_STR_LEN("DOCUMENT_ROOT"), CONST_BUF_LEN(con->physical.basedir));
 	}
-	scgi_env_add(p->scgi_env, CONST_STR_LEN("REQUEST_URI"), CONST_BUF_LEN(con->request.orig_uri));
-	if (!buffer_is_equal(con->request.uri, con->request.orig_uri)) {
-		scgi_env_add(p->scgi_env, CONST_STR_LEN("REDIRECT_URI"), CONST_BUF_LEN(con->request.uri));
+	if (con->error_handler_saved_status >= 0) {
+		scgi_env_add(p->scgi_env, CONST_STR_LEN("REQUEST_URI"), CONST_BUF_LEN(con->request.uri));
+	} else {
+		scgi_env_add(p->scgi_env, CONST_STR_LEN("REQUEST_URI"), CONST_BUF_LEN(con->request.orig_uri));
 	}
 	if (!buffer_string_is_empty(con->uri.query)) {
 		scgi_env_add(p->scgi_env, CONST_STR_LEN("QUERY_STRING"), CONST_BUF_LEN(con->uri.query));

--- a/src/mod_scgi.c
+++ b/src/mod_scgi.c
@@ -1661,7 +1661,11 @@ static int scgi_create_env(server *srv, handler_ctx *hctx) {
 	s = get_http_method_name(con->request.http_method);
 	force_assert(s);
 	scgi_env_add(p->scgi_env, CONST_STR_LEN("REQUEST_METHOD"), s, strlen(s));
-	scgi_env_add(p->scgi_env, CONST_STR_LEN("REDIRECT_STATUS"), CONST_STR_LEN("200")); /* if php is compiled with --force-redirect */
+	/* set REDIRECT_STATUS for php compiled with --force-redirect
+	 * (if REDIRECT_STATUS has not already been set by error handler) */
+	if (0 == con->error_handler_saved_status) {
+		scgi_env_add(p->scgi_env, CONST_STR_LEN("REDIRECT_STATUS"), CONST_STR_LEN("200"));
+	}
 	s = get_http_version_name(con->request.http_version);
 	force_assert(s);
 	scgi_env_add(p->scgi_env, CONST_STR_LEN("SERVER_PROTOCOL"), s, strlen(s));

--- a/src/mod_scgi.c
+++ b/src/mod_scgi.c
@@ -825,11 +825,12 @@ static int scgi_spawn_connection(server *srv,
 					}
 				}
 			} else {
-				for (i = 0; environ[i]; i++) {
+				char ** const e = environ;
+				for (i = 0; e[i]; ++i) {
 					char *eq;
 
-					if (NULL != (eq = strchr(environ[i], '='))) {
-						env_add(&env, environ[i], eq - environ[i], eq+1, strlen(eq+1));
+					if (NULL != (eq = strchr(e[i], '='))) {
+						env_add(&env, e[i], eq - e[i], eq+1, strlen(eq+1));
 					}
 				}
 			}
@@ -1576,7 +1577,8 @@ static int scgi_create_env(server *srv, handler_ctx *hctx) {
 	/* get the server-side of the connection to the client */
 	our_addr_len = sizeof(our_addr);
 
-	if (-1 == getsockname(con->fd, &(our_addr.plain), &our_addr_len)) {
+	if (-1 == getsockname(con->fd, (struct sockaddr *)&our_addr, &our_addr_len)
+	    || our_addr_len > sizeof(our_addr)) {
 		s = inet_ntop_cache_get_ip(srv, &(srv_sock->addr));
 	} else {
 		s = inet_ntop_cache_get_ip(srv, &(our_addr));

--- a/src/mod_scgi.c
+++ b/src/mod_scgi.c
@@ -996,7 +996,7 @@ SETDEFAULTS_FUNC(mod_scgi_set_defaults) {
 
 			if (du->type != TYPE_ARRAY) {
 				log_error_write(srv, __FILE__, __LINE__, "sss",
-						"unexpected type for key: ", "scgi.server", "array of strings");
+						"unexpected type for key: ", "scgi.server", "expected ( \"ext\" => ( \"backend-label\" => ( \"key\" => \"value\" )))");
 
 				goto error;
 			}
@@ -1014,7 +1014,7 @@ SETDEFAULTS_FUNC(mod_scgi_set_defaults) {
 				if (da->value->data[j]->type != TYPE_ARRAY) {
 					log_error_write(srv, __FILE__, __LINE__, "sssbs",
 							"unexpected type for key: ", "scgi.server",
-							"[", da->value->data[j]->key, "](string)");
+							"[", da->value->data[j]->key, "](string); expected ( \"ext\" => ( \"backend-label\" => ( \"key\" => \"value\" )))");
 
 					goto error;
 				}
@@ -1061,7 +1061,7 @@ SETDEFAULTS_FUNC(mod_scgi_set_defaults) {
 						log_error_write(srv, __FILE__, __LINE__, "ssSBS",
 								"unexpected type for key:",
 								"scgi.server",
-								"[", da_host->key, "](string)");
+								"[", da_host->key, "](string); expected ( \"ext\" => ( \"backend-label\" => ( \"key\" => \"value\" )))");
 
 						goto error;
 					}

--- a/src/mod_ssi.c
+++ b/src/mod_ssi.c
@@ -290,8 +290,12 @@ static int build_ssi_cgi_vars(server *srv, connection *con, plugin_data *p) {
 
 	ssi_env_add(p->ssi_cgi_env, CONST_STRING("QUERY_STRING"), buffer_is_empty(con->uri.query) ? "" : con->uri.query->ptr);
 	ssi_env_add(p->ssi_cgi_env, CONST_STRING("REQUEST_METHOD"), get_http_method_name(con->request.http_method));
-	ssi_env_add(p->ssi_cgi_env, CONST_STRING("REDIRECT_STATUS"), "200");
 	ssi_env_add(p->ssi_cgi_env, CONST_STRING("SERVER_PROTOCOL"), get_http_version_name(con->request.http_version));
+	/* set REDIRECT_STATUS for php compiled with --force-redirect
+	 * (if REDIRECT_STATUS has not already been set by error handler) */
+	if (0 == con->error_handler_saved_status) {
+		ssi_env_add(p->ssi_cgi_env, CONST_STRING("REDIRECT_STATUS"), "200");
+	}
 
 	ssi_env_add_request_headers(srv, con, p);
 

--- a/src/response.c
+++ b/src/response.c
@@ -448,7 +448,6 @@ handler_t http_response_prepare(server *srv, connection *con) {
 		if (con->physical.rel_path->used > 1) {
 			buffer *b = con->physical.rel_path;
 			size_t len = buffer_string_length(b);
-			size_t i;
 
 			/* strip trailing " /" or "./" once */
 			if (len > 1 &&

--- a/src/response.c
+++ b/src/response.c
@@ -167,7 +167,8 @@ static void https_add_ssl_entries(connection *con) {
 		buffer_append_string(envds->key, xobjsn);
 		buffer_copy_string_len(
 			envds->value,
-			(const char *)xe->value->data, xe->value->length
+			(const char *)X509_NAME_ENTRY_get_data(xe)->data,
+			X509_NAME_ENTRY_get_data(xe)->length
 		);
 		/* pick one of the exported values as "REMOTE_USER", for example
 		 * ssl.verifyclient.username   = "SSL_CLIENT_S_DN_UID" or "SSL_CLIENT_S_DN_emailAddress"

--- a/src/server.c
+++ b/src/server.c
@@ -343,6 +343,7 @@ static void server_free(server *srv) {
 			buffer_free(s->ssl_dh_file);
 			buffer_free(s->ssl_ec_curve);
 			buffer_free(s->error_handler);
+			buffer_free(s->error_handler_404);
 			buffer_free(s->errorfile_prefix);
 			array_free(s->mimetypes);
 			buffer_free(s->ssl_verifyclient_username);

--- a/src/server.c
+++ b/src/server.c
@@ -835,7 +835,7 @@ int main (int argc, char **argv) {
 		}
 
 		if (srv->event_handler == FDEVENT_HANDLER_SELECT) {
-			srv->max_fds = rlim.rlim_cur < ((int)FD_SETSIZE) - 200 ? rlim.rlim_cur : FD_SETSIZE - 200;
+			srv->max_fds = rlim.rlim_cur < (rlim_t)FD_SETSIZE - 200 ? (int)rlim.rlim_cur : (int)FD_SETSIZE - 200;
 		} else {
 			srv->max_fds = rlim.rlim_cur;
 		}
@@ -970,7 +970,7 @@ int main (int argc, char **argv) {
 		}
 
 		if (srv->event_handler == FDEVENT_HANDLER_SELECT) {
-			srv->max_fds = rlim.rlim_cur < ((int)FD_SETSIZE) - 200 ? rlim.rlim_cur : FD_SETSIZE - 200;
+			srv->max_fds = rlim.rlim_cur < (rlim_t)FD_SETSIZE - 200 ? (int)rlim.rlim_cur : (int)FD_SETSIZE - 200;
 		} else {
 			srv->max_fds = rlim.rlim_cur;
 		}

--- a/src/server.c
+++ b/src/server.c
@@ -381,7 +381,13 @@ static void server_free(server *srv) {
 	if (srv->ssl_is_init) {
 		CRYPTO_cleanup_all_ex_data();
 		ERR_free_strings();
+	      #if   OPENSSL_VERSION_NUMBER >= 0x10100000L
+		ERR_remove_thread_state();
+	      #elif OPENSSL_VERSION_NUMBER >= 0x10000000L
+		ERR_remove_thread_state(NULL);
+	      #else
 		ERR_remove_state(0);
+	      #endif
 		EVP_cleanup();
 	}
 #endif

--- a/tests/404-handler.conf
+++ b/tests/404-handler.conf
@@ -37,6 +37,9 @@ cgi.assign = (
 $HTTP["url"] =~ "^/static/" {
 	server.error-handler-404 = "/404.html"
 }
+else $HTTP["url"] =~ "^/dynamic/redirect_status/" {
+	server.error-handler     = "/404.pl"
+}
 else $HTTP["url"] =~ "." {
 	server.error-handler-404 = "/404.pl"
 }

--- a/tests/core-404-handler.t
+++ b/tests/core-404-handler.t
@@ -18,7 +18,7 @@ BEGIN {
 
 use strict;
 use IO::Socket;
-use Test::More tests => 8;
+use Test::More tests => 9;
 use LightyTest;
 
 my $tf = LightyTest->new();
@@ -57,6 +57,13 @@ EOF
  );
 $t->{RESPONSE} = [ { 'HTTP-Protocol' => 'HTTP/1.0', 'HTTP-Status' => 404, 'HTTP-Content' => "Not found here\n" } ];
 ok($tf->handle_http($t) == 0, '404 handler => dynamic(404)');
+
+$t->{REQUEST}  = ( <<EOF
+GET /dynamic/redirect_status/ HTTP/1.0
+EOF
+ );
+$t->{RESPONSE} = [ { 'HTTP-Protocol' => 'HTTP/1.0', 'HTTP-Status' => 404, 'HTTP-Content' => "REDIRECT_STATUS\n" } ];
+ok($tf->handle_http($t) == 0, 'error handler => dynamic(REDIRECT_STATUS)');
 
 $t->{REQUEST}  = ( <<EOF
 GET /dynamic/nostatus/notfound HTTP/1.0

--- a/tests/docroot/www/404.pl
+++ b/tests/docroot/www/404.pl
@@ -3,8 +3,10 @@
 use CGI qw/:standard/;
 
 my $cgi = new CGI;
-my $request_uri = $ENV{'REQUEST_URI'};
-print (STDERR "REQUEST_URI: $request_uri\n");
+my $request_uri = $ENV{'REQUEST_URI'};  # server.error-handler-404
+my $redirect_uri= $ENV{'REDIRECT_URI'}; # server.error-handler
+print (STDERR "REQUEST_URI:  $request_uri\n");
+print (STDERR "REDIRECT_URI: $redirect_uri\n");
 
 if ($request_uri =~ m/^\/dynamic\/200\// ) {
   print header ( -status => 200,
@@ -27,6 +29,11 @@ elsif ($request_uri =~ m/^\/send404\.pl/ ) {
 }
 elsif ($request_uri =~ m/^\/dynamic\/nostatus\// ) {
   print ("found here\n");
+}
+elsif ($redirect_uri =~ m/^\/dynamic\/redirect_status\// ) {
+  print header ( -status => $ENV{'REDIRECT_STATUS'},
+                 -type   => 'text/plain');
+  print ("REDIRECT_STATUS\n");
 }
 else {
   print header ( -status => 500,


### PR DESCRIPTION
server.error-handler preserves HTTP status error code when error page is static, and allows dynamic handlers to change HTTP status code when error page is provided by dynamic handler.  server.error-handler intercepts all HTTP status codes >= 400 except when the content is generated by a dynamic handler (cgi, ssi, fastcgi, scgi, proxy, lua).  The request method is unconditionally changed to GET for the request to service the error handler, and the original request method is later restored (for logging purposes).  request body from the original request, if present, is discarded.
    
server.error-handler is somewhat similar to server.error-handler-404, but server.error-handler-404 is now deprecated, intercepts only 404 and 403 HTTP status codes, and returns 200 OK for static error pages, a source of confusion for some admins.  On the other hand, the new server.error-handler, when set, will intercept all HTTP status error codes >= 400.  server.error-handler takes precedence over server.error-handler-404 when both are set.
    
NOTE: a major difference between server.error-handler and the now-deprecated server.error-handler-404 is that the values of the non-standard CGI environment variables REQUEST_URI and REDIRECT_URI have been swapped.  Since REDIRECT_STATUS is the original HTTP status code, REDIRECT_URI is now the original request, and REQUEST_URI is the current request (e.g. the URI/URL to the error handler).  The prior behavior -- which reversed REQUEST_URI and REDIRECT_URI values from those described above -- is preserved for server.error-handler-404.
    
Additionally, REDIRECT_STATUS is now available to mod_magnet, which continues to have access to request.uri and request.orig_uri.
    
See further discussion at https://redmine.lighttpd.net/issues/2702 and https://redmine.lighttpd.net/issues/1828