### PR TITLE
command line opt to shutdown after idle time limit

### DIFF
--- a/doc/lighttpd.8
+++ b/doc/lighttpd.8
@@ -39,6 +39,9 @@ Test the configuration file for syntax errors, load and initialize modules, and 
 \fB\-D\fP
 Do not daemonize (go into background). The default is to daemonize.
 .TP 8
+\fB\-i\ \fP \fIsecs\fP
+Trigger daemon graceful shutdown after \fIsecs\fP of inactivity.
+.TP 8
 \fB\-v\fP
 Show version and exit.
 .TP 8

--- a/doc/lighttpd.8
+++ b/doc/lighttpd.8
@@ -42,6 +42,9 @@ Do not daemonize (go into background). The default is to daemonize.
 \fB\-i\ \fP \fIsecs\fP
 Trigger daemon graceful shutdown after \fIsecs\fP of inactivity.
 .TP 8
+\fB\-1\fP
+Process single (one) request on stdin socket, then exit.
+.TP 8
 \fB\-v\fP
 Show version and exit.
 .TP 8

--- a/src/connections.c
+++ b/src/connections.c
@@ -894,6 +894,11 @@ connection *connection_accept(server *srv, server_socket *srv_socket) {
 		}
 		return NULL;
 	} else {
+		return connection_accepted(srv, srv_socket, &cnt_addr, cnt);
+	}
+}
+
+connection *connection_accepted(server *srv, server_socket *srv_socket, sock_addr *cnt_addr, int cnt) {
 		connection *con;
 
 		srv->cur_fds++;
@@ -917,7 +922,7 @@ connection *connection_accept(server *srv, server_socket *srv_socket) {
 		connection_set_state(srv, con, CON_STATE_REQUEST_START);
 
 		con->connection_start = srv->cur_ts;
-		con->dst_addr = cnt_addr;
+		con->dst_addr = *cnt_addr;
 		buffer_copy_string(con->dst_addr_buf, inet_ntop_cache_get_ip(srv, &(con->dst_addr)));
 		con->srv_socket = srv_socket;
 
@@ -947,7 +952,6 @@ connection *connection_accept(server *srv, server_socket *srv_socket) {
 		}
 #endif
 		return con;
-	}
 }
 
 

--- a/src/connections.h
+++ b/src/connections.h
@@ -10,6 +10,7 @@ int connection_reset(server *srv, connection *con);
 void connections_free(server *srv);
 
 connection * connection_accept(server *srv, server_socket *srv_sock);
+connection * connection_accepted(server *srv, server_socket *srv_socket, sock_addr *cnt_addr, int cnt);
 
 int connection_set_state(server *srv, connection *con, connection_state_t state);
 const char * connection_get_state(connection_state_t state);

--- a/src/network.c
+++ b/src/network.c
@@ -157,8 +157,6 @@ static int network_server_init(server *srv, buffer *host_token, specific_config 
 	unsigned int port = 0;
 	const char *host;
 	buffer *b;
-	int is_unix_domain_socket = 0;
-	int fd;
 	int err;
 
 #ifdef __WIN32
@@ -178,6 +176,7 @@ static int network_server_init(server *srv, buffer *host_token, specific_config 
 
 	srv_socket = calloc(1, sizeof(*srv_socket));
 	force_assert(NULL != srv_socket);
+	srv_socket->addr.plain.sa_family = AF_INET; /* default */
 	srv_socket->fd = -1;
 	srv_socket->fde_ndx = -1;
 
@@ -191,7 +190,13 @@ static int network_server_init(server *srv, buffer *host_token, specific_config 
 
 	if (host[0] == '/') {
 		/* host is a unix-domain-socket */
-		is_unix_domain_socket = 1;
+#ifdef HAVE_SYS_UN_H
+		srv_socket->addr.plain.sa_family = AF_UNIX;
+#else
+		log_error_write(srv, __FILE__, __LINE__, "s",
+				"ERROR: Unix Domain sockets are not supported.");
+		goto error_free_socket;
+#endif
 	} else {
 		/* ipv4:port
 		 * [ipv6]:port
@@ -229,52 +234,11 @@ static int network_server_init(server *srv, buffer *host_token, specific_config 
 
 	if (*host == '\0') host = NULL;
 
-	if (is_unix_domain_socket) {
-#ifdef HAVE_SYS_UN_H
-
-		srv_socket->addr.plain.sa_family = AF_UNIX;
-
-		if (-1 == (srv_socket->fd = socket(srv_socket->addr.plain.sa_family, SOCK_STREAM, 0))) {
-			log_error_write(srv, __FILE__, __LINE__, "ss", "socket failed:", strerror(errno));
-			goto error_free_socket;
-		}
-#else
-		log_error_write(srv, __FILE__, __LINE__, "s",
-				"ERROR: Unix Domain sockets are not supported.");
-		goto error_free_socket;
-#endif
-	}
-
 #ifdef HAVE_IPV6
 	if (s->use_ipv6) {
 		srv_socket->addr.plain.sa_family = AF_INET6;
-
-		if (-1 == (srv_socket->fd = socket(srv_socket->addr.plain.sa_family, SOCK_STREAM, IPPROTO_TCP))) {
-			log_error_write(srv, __FILE__, __LINE__, "ss", "socket failed:", strerror(errno));
-			goto error_free_socket;
-		}
 	}
 #endif
-
-	if (srv_socket->fd == -1) {
-		srv_socket->addr.plain.sa_family = AF_INET;
-		if (-1 == (srv_socket->fd = socket(srv_socket->addr.plain.sa_family, SOCK_STREAM, IPPROTO_TCP))) {
-			log_error_write(srv, __FILE__, __LINE__, "ss", "socket failed:", strerror(errno));
-			goto error_free_socket;
-		}
-	}
-
-	/* set FD_CLOEXEC now, fdevent_fcntl_set is called later; needed for pipe-logger forks */
-	fd_close_on_exec(srv_socket->fd);
-
-	/* */
-	srv->cur_fds = srv_socket->fd;
-
-	val = 1;
-	if (setsockopt(srv_socket->fd, SOL_SOCKET, SO_REUSEADDR, &val, sizeof(val)) < 0) {
-		log_error_write(srv, __FILE__, __LINE__, "ss", "socketsockopt(SO_REUSEADDR) failed:", strerror(errno));
-		goto error_free_socket;
-	}
 
 	switch(srv_socket->addr.plain.sa_family) {
 #ifdef HAVE_IPV6
@@ -287,16 +251,6 @@ static int network_server_init(server *srv, buffer *host_token, specific_config 
 		} else {
 			struct addrinfo hints, *res;
 			int r;
-
-			if (s->set_v6only) {
-				val = 1;
-				if (-1 == setsockopt(srv_socket->fd, IPPROTO_IPV6, IPV6_V6ONLY, &val, sizeof(val))) {
-					log_error_write(srv, __FILE__, __LINE__, "ss", "socketsockopt(IPV6_V6ONLY) failed:", strerror(errno));
-					goto error_free_socket;
-				}
-			} else {
-				log_error_write(srv, __FILE__, __LINE__, "s", "warning: server.set-v6only will be removed soon, update your config to have different sockets for ipv4 and ipv6");
-			}
 
 			memset(&hints, 0, sizeof(hints));
 
@@ -347,10 +301,9 @@ static int network_server_init(server *srv, buffer *host_token, specific_config 
 			memcpy(&(srv_socket->addr.ipv4.sin_addr.s_addr), he->h_addr_list[0], he->h_length);
 		}
 		srv_socket->addr.ipv4.sin_port = htons(port);
-
 		addr_len = sizeof(struct sockaddr_in);
-
 		break;
+#ifdef HAVE_SYS_UN_H
 	case AF_UNIX:
 		memset(&srv_socket->addr, 0, sizeof(struct sockaddr_un));
 		srv_socket->addr.un.sun_family = AF_UNIX;
@@ -370,12 +323,25 @@ static int network_server_init(server *srv, buffer *host_token, specific_config 
 #endif
 		}
 
-		if (srv->srvconf.preflight_check) break;
+		break;
+#endif
+	default:
+		goto error_free_socket;
+	}
 
+	if (srv->srvconf.preflight_check) {
+		err = 0;
+		goto error_free_socket;
+	}
+
+#ifdef HAVE_SYS_UN_H
+	if (AF_UNIX == srv_socket->addr.plain.sa_family) {
 		/* check if the socket exists and try to connect to it. */
-		if (-1 != (fd = connect(srv_socket->fd, (struct sockaddr *) &(srv_socket->addr), addr_len))) {
-			close(fd);
-
+		if (-1 == (srv_socket->fd = socket(srv_socket->addr.plain.sa_family, SOCK_STREAM, 0))) {
+			log_error_write(srv, __FILE__, __LINE__, "ss", "socket failed:", strerror(errno));
+			goto error_free_socket;
+		}
+		if (0 == connect(srv_socket->fd, (struct sockaddr *) &(srv_socket->addr), addr_len)) {
 			log_error_write(srv, __FILE__, __LINE__, "ss",
 				"server socket is still in use:",
 				host);
@@ -398,14 +364,39 @@ static int network_server_init(server *srv, buffer *host_token, specific_config 
 
 			goto error_free_socket;
 		}
+	} else
+#endif
+	{
+		if (-1 == (srv_socket->fd = socket(srv_socket->addr.plain.sa_family, SOCK_STREAM, IPPROTO_TCP))) {
+			log_error_write(srv, __FILE__, __LINE__, "ss", "socket failed:", strerror(errno));
+			goto error_free_socket;
+		}
 
-		break;
-	default:
-		goto error_free_socket;
+#ifdef HAVE_IPV6
+		if (AF_INET6 == srv_socket->addr.plain.sa_family
+		    && host != NULL) {
+			if (s->set_v6only) {
+				val = 1;
+				if (-1 == setsockopt(srv_socket->fd, IPPROTO_IPV6, IPV6_V6ONLY, &val, sizeof(val))) {
+					log_error_write(srv, __FILE__, __LINE__, "ss", "socketsockopt(IPV6_V6ONLY) failed:", strerror(errno));
+					goto error_free_socket;
+				}
+			} else {
+				log_error_write(srv, __FILE__, __LINE__, "s", "warning: server.set-v6only will be removed soon, update your config to have different sockets for ipv4 and ipv6");
+			}
+		}
+#endif
 	}
 
-	if (srv->srvconf.preflight_check) {
-		err = 0;
+	/* set FD_CLOEXEC now, fdevent_fcntl_set is called later; needed for pipe-logger forks */
+	fd_close_on_exec(srv_socket->fd);
+
+	/* */
+	srv->cur_fds = srv_socket->fd;
+
+	val = 1;
+	if (setsockopt(srv_socket->fd, SOL_SOCKET, SO_REUSEADDR, &val, sizeof(val)) < 0) {
+		log_error_write(srv, __FILE__, __LINE__, "ss", "socketsockopt(SO_REUSEADDR) failed:", strerror(errno));
 		goto error_free_socket;
 	}
 


### PR DESCRIPTION
-i <secs>  graceful shutdown after <secs> of inactivity

Option might be used with applications such as git instaweb.  While git instaweb does have command line options of its own to [start,stop,restart], some may find it convenient to configure git instaweb to start lighttpd with a default idle time limit, after which lighttpd will gracefully shut itself down without any further action from the user.

x-ref:
  "[PATCH] support -i <secs> idle timeout option"
  https://redmine.lighttpd.net/issues/2696
  original request and patch submitted by mackyle.  thx.