### PR TITLE
lighttpd -tt performs preflight startup checks

### DIFF
--- a/src/base.h
+++ b/src/base.h
@@ -510,6 +510,7 @@ typedef struct {
 	buffer *breakagelog_file;
 
 	unsigned short dont_daemonize;
+	unsigned short preflight_check;
 	buffer *changeroot;
 	buffer *username;
 	buffer *groupname;

--- a/src/mod_accesslog.c
+++ b/src/mod_accesslog.c
@@ -584,6 +584,8 @@ SETDEFAULTS_FUNC(log_access_open) {
 
 		if (buffer_string_is_empty(s->access_logfile)) continue;
 
+		if (srv->srvconf.preflight_check) continue;
+
 		if (-1 == (s->log_access_fd = open_logfile_or_pipe(srv, s->access_logfile->ptr)))
 			return HANDLER_ERROR;
 


### PR DESCRIPTION
lighttpd -t loads config file and performs syntax check
lighttpd -tt (new) performs preflight startup checks,
  including loading and initializing modules, but skipping any
  potentially destructive actions which might affect an already
  running server (separate instance).  These currently include:
  - skipping pidfile modification
  - skipping bind() to network sockets
  - skipping open of error and access logs

x-ref:
  "typo in config file did not show up in a config-test"
  https://redmine.lighttpd.net/issues/411