### PR TITLE
mimetype.xattr-name global config option

### DIFF
--- a/src/base.h
+++ b/src/base.h
@@ -541,6 +541,7 @@ typedef struct {
 	} stat_cache_engine;
 	unsigned short enable_cores;
 	unsigned short reject_expect_100_with_417;
+	buffer *xattr_name;
 } server_config;
 
 typedef struct server_socket {

--- a/src/configfile.c
+++ b/src/configfile.c
@@ -110,6 +110,7 @@ static int config_insert(server *srv) {
 		{ "ssl.honor-cipher-order",            NULL, T_CONFIG_BOOLEAN, T_CONFIG_SCOPE_CONNECTION }, /* 66 */
 		{ "ssl.empty-fragments",               NULL, T_CONFIG_BOOLEAN, T_CONFIG_SCOPE_CONNECTION }, /* 67 */
 		{ "server.upload-temp-file-size",      NULL, T_CONFIG_INT,     T_CONFIG_SCOPE_SERVER     }, /* 68 */
+		{ "mimetype.xattr-name",               NULL, T_CONFIG_STRING,  T_CONFIG_SCOPE_SERVER     }, /* 69 */
 
 		{ "server.host",
 			"use server.bind instead",
@@ -173,6 +174,7 @@ static int config_insert(server *srv) {
 	cv[55].destination = srv->srvconf.breakagelog_file;
 
 	cv[68].destination = &(srv->srvconf.upload_temp_file_size);
+	cv[69].destination = srv->srvconf.xattr_name;
 
 	srv->config_storage = calloc(1, srv->config_context->used * sizeof(specific_config *));
 

--- a/src/mod_dirlisting.c
+++ b/src/mod_dirlisting.c
@@ -821,7 +821,7 @@ static int http_list_directory(server *srv, connection *con, plugin_data *p, buf
 		if (con->conf.use_xattr) {
 			memcpy(path_file, DIRLIST_ENT_NAME(tmp), tmp->namelen + 1);
 			attrlen = sizeof(attrval) - 1;
-			if (attr_get(path, "Content-Type", attrval, &attrlen, 0) == 0) {
+			if (attr_get(path, srv->srvconf.xattr_name->ptr, attrval, &attrlen, 0) == 0) {
 				attrval[attrlen] = '\0';
 				content_type = attrval;
 			}
@@ -829,7 +829,7 @@ static int http_list_directory(server *srv, connection *con, plugin_data *p, buf
 #elif defined(HAVE_EXTATTR)
 		if (con->conf.use_xattr) {
 			memcpy(path_file, DIRLIST_ENT_NAME(tmp), tmp->namelen + 1);
-			if(-1 != (attrlen = extattr_get_file(path, EXTATTR_NAMESPACE_USER, "Content-Type", attrval, sizeof(attrval)-1))) {
+			if(-1 != (attrlen = extattr_get_file(path, EXTATTR_NAMESPACE_USER, srv->srvconf.xattr_name->ptr, attrval, sizeof(attrval)-1))) {
 				attrval[attrlen] = '\0';
 				content_type = attrval;
 			}

--- a/src/server.c
+++ b/src/server.c
@@ -245,6 +245,7 @@ static server *server_init(void) {
 	srv->srvconf.network_backend = buffer_init();
 	srv->srvconf.upload_tempdirs = array_init();
 	srv->srvconf.reject_expect_100_with_417 = 1;
+	srv->srvconf.xattr_name = buffer_init_string("Content-Type");
 
 	/* use syslog */
 	srv->errorlog_fd = STDERR_FILENO;
@@ -285,6 +286,7 @@ static void server_free(server *srv) {
 	CLEAN(srvconf.pid_file);
 	CLEAN(srvconf.modules_dir);
 	CLEAN(srvconf.network_backend);
+	CLEAN(srvconf.xattr_name);
 
 	CLEAN(tmp_chunk_len);
 #undef CLEAN


### PR DESCRIPTION
For backwards compatibility with existing lighttpd configs, default is
  mimetype.xattr-name = "Content-Type"

Those who wish to use the freedesktop.org definition of xattr mimetype
can set the following in the global lighttpd config:
  mimetype.xattr-name = "user.mime_type"

x-ref:
  "Migrate to freedesktop.org definition of xattr mimetype"
  https://redmine.lighttpd.net/issues/2631