### PR TITLE
Update base64.c

### DIFF
--- a/src/base64.c
+++ b/src/base64.c
@@ -144,7 +144,7 @@ size_t li_to_base64_no_padding(char* out, size_t out_length, const unsigned char
 	/* check overflows */
 	force_assert(full_tuples < 2*full_tuples);
 	force_assert(full_tuples < 4*full_tuples);
-	force_assert(4*full_tuples < 4*full_tuples + out_tuple_remainder);
+	force_assert(4*full_tuples <= 4*full_tuples + out_tuple_remainder);
 	force_assert(require_space <= out_length);
 
 	for (i = 2; i < in_length; i += 3) {


### PR DESCRIPTION
If `in_tupre_reminder` is `0`, then `out_tuple_reminder` is `0` too, and `4*full_tuples` can be equal to `4*full_tuples + out_tuple_remainder`.