### PR TITLE
[mod_ssi] config ssi.conditional-requests

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -74,6 +74,7 @@ NEWS
   * [mod_dirlisting] class for dir <tr> (fixes #2304)
   * [core] define __STDC_WANT_LIB_EXT1__ (fixes #2722)
   * [core] setrlimit max-fds <= rlim_max for non-root (fixes #2723)
+  * [mod_ssi] config ssi.conditional-requests
 
 - 1.4.39 - 2016-01-02
   * [core] fix memset_s call (fixes #2698)

--- a/doc/config/conf.d/ssi.conf
+++ b/doc/config/conf.d/ssi.conf
@@ -1,6 +1,6 @@
 #######################################################################
 ##
-##  Server Side Includes 
+##  Server Side Includes
 ## -----------------------
 ##
 ## See http://redmine.lighttpd.net/projects/lighttpd/wiki/Docs_ModSSI
@@ -11,6 +11,35 @@ server.modules += ( "mod_ssi" )
 ## which extensions should be ran through mod_ssi.
 ##
 ssi.extension              = ( ".shtml" )
+
+##
+## The  ssi.conditional-requests  directive only affects requests
+## handled by the SSI module and allows to declare which SSI pages
+## are cacheable and which are not. This directive can be enabled
+## or disabled globally and/or in any context.
+##
+## As the name of this directive suggests, conditional requests will
+## be handled appropriately for any SSI page for which the directive
+## is enabled. In particular, the "ETag" and "Last-Modified" headers
+## will both be sent. Conversely, these headers will NOT be sent for
+## pages for which the directive is disabled.
+##
+## The directive should be set to "enable" ONLY for requests that are
+## known to generate cacheable documents. An SSI page which only
+## includes contents from other static files and/or which uses SSI
+## commands that produce predictable output (e.g. the echo command
+## for the LAST_MODIFIED variable) is likely to be cacheable.
+##
+## The directive should be set to "disable" for ALL other documents,
+## that is, for SSI pages which depend on non-predictable input such
+## as (but not limited to) output from ssi exec commands, data from
+## the client's request headers (other than the request URI), or any
+## other non constant input such as the current date or time, the
+## client's user-agent, etc...
+##
+## Disabled by default.
+##
+#ssi.conditional-requests = "enable"
 
 ##
 #######################################################################

--- a/src/mod_ssi.h
+++ b/src/mod_ssi.h
@@ -17,6 +17,7 @@
 typedef struct {
 	array *ssi_extension;
 	buffer *content_type;
+	unsigned short conditional_requests;
 } plugin_config;
 
 typedef struct {


### PR DESCRIPTION
Summary:
A new SSI directive, «**`ssi.conditional-requests`**», allows to inform lighttpd which SSI pages should be considered as cacheable and which should not. In particular, the **`ETag`** & **`Last-Modified`** headers will only be sent for those SSI pages for which the directive is enabled.

Long description:
**`ETag`** and **`Last-Modified`** headers were being sent for all SSI pages, regardless of whether they were cacheable or not. And yet, there was no cache validation at all for any SSI page.
This commit fixes these two minor issues by adding a new directive, «**`ssi.conditional-requests`**», which allows to specify which SSI pages are cacheable and which are not, and by adding cache validation to those SSI pages which are cacheable. And since sending ETags for non-cacheable documents is not appropriate, they are no longuer computed nor sent for those SSI pages which are not cacheable.
Regarding the **`Last-Modified`** header for non-cacheable documents, the standards allow to either send the current date and time for that header or to simply skip it. The approach chosen is to not send it for non-cacheable SSI pages. **`ETag`** and **`Last-Modified`** headers are therefore only sent for an SSI page if «**`ssi.conditional-requests`**» is enabled for that page.

The «**`ssi.conditional-requests`**» directive can be enabled or disabled globally and/or in any context. It is disabled by default.

An index.shtml which only includes determinist SSI commands such as:
**`<!--#echo var="LAST_MODIFIED"-->`**
is a trivial example of a dynamic SSI page that is cacheable.

Refs: [RFC7232](https://tools.ietf.org/html/rfc7232) & [RFC7234](https://tools.ietf.org/html/rfc7234).