### PR TITLE
http_chunk_append_file opens fd when adding to cq

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -75,6 +75,7 @@ NEWS
   * [core] define __STDC_WANT_LIB_EXT1__ (fixes #2722)
   * [core] setrlimit max-fds <= rlim_max for non-root (fixes #2723)
   * [mod_ssi] config ssi.conditional-requests
+  * [mod_ssi] config ssi.exec (fixes #2051)
 
 - 1.4.39 - 2016-01-02
   * [core] fix memset_s call (fixes #2698)

--- a/NEWS
+++ b/NEWS
@@ -78,6 +78,7 @@ NEWS
   * [mod_ssi] config ssi.exec (fixes #2051)
   * [mod_redirect,mod_rewrite] short-circuit if blank replacement (fixes #2085)
   * [mod_indexfile] save physical path to env (fixes #448, #892)
+  * [core] open fd when appending file to cq (fixes #2655)
 
 - 1.4.39 - 2016-01-02
   * [core] fix memset_s call (fixes #2698)

--- a/NEWS
+++ b/NEWS
@@ -77,6 +77,7 @@ NEWS
   * [mod_ssi] config ssi.conditional-requests
   * [mod_ssi] config ssi.exec (fixes #2051)
   * [mod_redirect,mod_rewrite] short-circuit if blank replacement (fixes #2085)
+  * [mod_indexfile] save physical path to env (fixes #448, #892)
 
 - 1.4.39 - 2016-01-02
   * [core] fix memset_s call (fixes #2698)

--- a/NEWS
+++ b/NEWS
@@ -74,6 +74,7 @@ NEWS
   * [mod_dirlisting] class for dir <tr> (fixes #2304)
   * [core] define __STDC_WANT_LIB_EXT1__ (fixes #2722)
   * [core] setrlimit max-fds <= rlim_max for non-root (fixes #2723)
+  * [mod_ssi] config ssi.conditional-requests
 
 - 1.4.39 - 2016-01-02
   * [core] fix memset_s call (fixes #2698)

--- a/NEWS
+++ b/NEWS
@@ -76,6 +76,7 @@ NEWS
   * [core] setrlimit max-fds <= rlim_max for non-root (fixes #2723)
   * [mod_ssi] config ssi.conditional-requests
   * [mod_ssi] config ssi.exec (fixes #2051)
+  * [mod_redirect,mod_rewrite] short-circuit if blank replacement (fixes #2085)
 
 - 1.4.39 - 2016-01-02
   * [core] fix memset_s call (fixes #2698)

--- a/doc/config/conf.d/ssi.conf
+++ b/doc/config/conf.d/ssi.conf
@@ -1,6 +1,6 @@
 #######################################################################
 ##
-##  Server Side Includes 
+##  Server Side Includes
 ## -----------------------
 ##
 ## See http://redmine.lighttpd.net/projects/lighttpd/wiki/Docs_ModSSI
@@ -11,6 +11,35 @@ server.modules += ( "mod_ssi" )
 ## which extensions should be ran through mod_ssi.
 ##
 ssi.extension              = ( ".shtml" )
+
+##
+## The  ssi.conditional-requests  directive only affects requests
+## handled by the SSI module and allows to declare which SSI pages
+## are cacheable and which are not. This directive can be enabled
+## or disabled globally and/or in any context.
+##
+## As the name of this directive suggests, conditional requests will
+## be handled appropriately for any SSI page for which the directive
+## is enabled. In particular, the "ETag" and "Last-Modified" headers
+## will both be sent. Conversely, these headers will NOT be sent for
+## pages for which the directive is disabled.
+##
+## The directive should be set to "enable" ONLY for requests that are
+## known to generate cacheable documents. An SSI page which only
+## includes contents from other static files and/or which uses SSI
+## commands that produce predictable output (e.g. the echo command
+## for the LAST_MODIFIED variable) is likely to be cacheable.
+##
+## The directive should be set to "disable" for ALL other documents,
+## that is, for SSI pages which depend on non-predictable input such
+## as (but not limited to) output from ssi exec commands, data from
+## the client's request headers (other than the request URI), or any
+## other non constant input such as the current date or time, the
+## client's user-agent, etc...
+##
+## Disabled by default.
+##
+#ssi.conditional-requests = "enable"
 
 ##
 #######################################################################

--- a/src/chunk.c
+++ b/src/chunk.c
@@ -203,6 +203,27 @@ void chunkqueue_reset(chunkqueue *cq) {
 	cq->bytes_out = 0;
 }
 
+void chunkqueue_append_file_fd(chunkqueue *cq, buffer *fn, int fd, off_t offset, off_t len) {
+	chunk *c;
+
+	if (0 == len) {
+		close(fd);
+		return;
+	}
+
+	c = chunkqueue_get_unused_chunk(cq);
+
+	c->type = FILE_CHUNK;
+
+	buffer_copy_buffer(c->file.name, fn);
+	c->file.start = offset;
+	c->file.length = len;
+	c->file.fd = fd;
+	c->offset = 0;
+
+	chunkqueue_append_chunk(cq, c);
+}
+
 void chunkqueue_append_file(chunkqueue *cq, buffer *fn, off_t offset, off_t len) {
 	chunk *c;
 

--- a/src/chunk.h
+++ b/src/chunk.h
@@ -51,6 +51,7 @@ typedef struct {
 chunkqueue *chunkqueue_init(void);
 void chunkqueue_set_tempdirs(chunkqueue *cq, array *tempdirs, unsigned int upload_temp_file_size);
 void chunkqueue_append_file(chunkqueue *cq, buffer *fn, off_t offset, off_t len); /* copies "fn" */
+void chunkqueue_append_file_fd(chunkqueue *cq, buffer *fn, int fd, off_t offset, off_t len); /* copies "fn" */
 void chunkqueue_append_mem(chunkqueue *cq, const char *mem, size_t len); /* copies memory */
 void chunkqueue_append_buffer(chunkqueue *cq, buffer *mem); /* may reset "mem" */
 void chunkqueue_prepend_buffer(chunkqueue *cq, buffer *mem); /* may reset "mem" */

--- a/src/connections.c
+++ b/src/connections.c
@@ -495,11 +495,11 @@ static int connection_handle_write_prepare(server *srv, connection *con) {
 			buffer_append_int(con->physical.path, con->http_status);
 			buffer_append_string_len(con->physical.path, CONST_STR_LEN(".html"));
 
-			if (HANDLER_ERROR != stat_cache_get_entry(srv, con, con->physical.path, &sce)) {
+			if (0 == http_chunk_append_file(srv, con, con->physical.path)) {
 				con->file_finished = 1;
-
-				http_chunk_append_file(srv, con, con->physical.path, 0, sce->st.st_size);
-				response_header_overwrite(srv, con, CONST_STR_LEN("Content-Type"), CONST_BUF_LEN(sce->content_type));
+				if (HANDLER_ERROR != stat_cache_get_entry(srv, con, con->physical.path, &sce)) {
+					response_header_overwrite(srv, con, CONST_STR_LEN("Content-Type"), CONST_BUF_LEN(sce->content_type));
+				}
 			}
 		}
 

--- a/src/http_chunk.h
+++ b/src/http_chunk.h
@@ -7,7 +7,8 @@
 
 void http_chunk_append_mem(server *srv, connection *con, const char * mem, size_t len); /* copies memory */
 void http_chunk_append_buffer(server *srv, connection *con, buffer *mem); /* may reset "mem" */
-void http_chunk_append_file(server *srv, connection *con, buffer *fn, off_t offset, off_t len); /* copies "fn" */
+int http_chunk_append_file(server *srv, connection *con, buffer *fn); /* copies "fn" */
+int http_chunk_append_file_range(server *srv, connection *con, buffer *fn, off_t offset, off_t len); /* copies "fn" */
 void http_chunk_close(server *srv, connection *con);
 
 #endif

--- a/src/mod_redirect.c
+++ b/src/mod_redirect.c
@@ -209,6 +209,10 @@ static handler_t mod_redirect_uri_handler(server *srv, connection *con, void *p_
 						"execution error while matching: ", n);
 				return HANDLER_ERROR;
 			}
+		} else if (0 == pattern_len) {
+			/* short-circuit if blank replacement pattern
+			 * (do not attempt to match against remaining redirect rules) */
+			return HANDLER_GO_ON;
 		} else {
 			const char **list;
 			size_t start;

--- a/src/mod_rewrite.c
+++ b/src/mod_rewrite.c
@@ -383,6 +383,10 @@ static handler_t process_rewrite_rules(server *srv, connection *con, plugin_data
 						"execution error while matching: ", n);
 				return HANDLER_ERROR;
 			}
+		} else if (0 == pattern_len) {
+			/* short-circuit if blank replacement pattern
+			 * (do not attempt to match against remaining rewrite rules) */
+			return HANDLER_GO_ON;
 		} else {
 			const char **list;
 			size_t start;

--- a/src/mod_ssi.h
+++ b/src/mod_ssi.h
@@ -18,6 +18,7 @@ typedef struct {
 	array *ssi_extension;
 	buffer *content_type;
 	unsigned short conditional_requests;
+	unsigned short ssi_exec;
 } plugin_config;
 
 typedef struct {

--- a/src/mod_ssi.h
+++ b/src/mod_ssi.h
@@ -17,6 +17,7 @@
 typedef struct {
 	array *ssi_extension;
 	buffer *content_type;
+	unsigned short conditional_requests;
 } plugin_config;
 
 typedef struct {

--- a/src/mod_staticfile.c
+++ b/src/mod_staticfile.c
@@ -540,10 +540,12 @@ URIHANDLER_FUNC(mod_staticfile_subrequest) {
 	/* we add it here for all requests
 	 * the HEAD request will drop it afterwards again
 	 */
-	http_chunk_append_file(srv, con, con->physical.path, 0, sce->st.st_size);
-
-	con->http_status = 200;
-	con->file_finished = 1;
+	if (0 == sce->st.st_size || 0 == http_chunk_append_file(srv, con, con->physical.path)) {
+		con->http_status = 200;
+		con->file_finished = 1;
+	} else {
+		con->http_status = 403;
+	}
 
 	return HANDLER_FINISHED;
 }

--- a/src/stat_cache.h
+++ b/src/stat_cache.h
@@ -9,6 +9,7 @@ void stat_cache_free(stat_cache *fc);
 
 handler_t stat_cache_get_entry(server *srv, connection *con, buffer *name, stat_cache_entry **fce);
 handler_t stat_cache_handle_fdevent(server *srv, void *_fce, int revent);
+int stat_cache_open_rdonly_fstat (server *srv, connection *con, buffer *name, struct stat *st);
 
 int stat_cache_trigger_cleanup(server *srv);
 #endif


### PR DESCRIPTION
and defers calculation of content length until response is finished

This reduces race conditions pertaining to stat() and then (later)
open(), when the result of the stat() was used for Content-Length
or to generate chunked headers.

Note: this does not change how lighttpd handles files that are modified
in-place by another process after having been opened by lighttpd --
don't do that.  This *does* improve handling of files that are
frequently modified via a temporary file and then atomically renamed
into place.

mod_fastcgi has been modified to use http_chunk_append_file_range() with
X-Sendfile2 and will open the target file multiple times if there are
multiple ranges.

Note: (future todo) not implemented for chunk.[ch] interfaces used by
range requests in mod_staticfile or by mod_ssi.  Those uses could lead
to too many open fds.  For mod_staticfile, limits should be put in place
for max number of ranges accepted by mod_staticfile.  For mod_ssi,
limits would need to be placed on the maximum number of includes, and
the primary SSI file split across lots of SSI directives should either
copy the pieces or perhaps chunk.h could be extended to allow for an
open fd to be shared across multiple chunks.  Doing either of these
would improve the performance of SSI since they would replace many file
opens on the pieces of the SSI file around the SSI directives.

x-ref:
  "Serving a file that is getting updated can cause an empty response or incorrect content-length error"
  https://redmine.lighttpd.net/issues/2655