### PR TITLE
[config] server.listen-backlog option

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -75,6 +75,7 @@ NEWS
   * [core] define __STDC_WANT_LIB_EXT1__ (fixes #2722)
   * [core] setrlimit max-fds <= rlim_max for non-root (fixes #2723)
   * [mod_ssi] config ssi.conditional-requests
+  * [mod_ssi] config ssi.exec (fixes #2051)
 
 - 1.4.39 - 2016-01-02
   * [core] fix memset_s call (fixes #2698)

--- a/NEWS
+++ b/NEWS
@@ -78,6 +78,7 @@ NEWS
   * [mod_ssi] config ssi.exec (fixes #2051)
   * [mod_redirect,mod_rewrite] short-circuit if blank replacement (fixes #2085)
   * [mod_indexfile] save physical path to env (fixes #448, #892)
+  * [core] open fd when appending file to cq (fixes #2655)
 
 - 1.4.39 - 2016-01-02
   * [core] fix memset_s call (fixes #2698)

--- a/NEWS
+++ b/NEWS
@@ -77,6 +77,7 @@ NEWS
   * [mod_ssi] config ssi.conditional-requests
   * [mod_ssi] config ssi.exec (fixes #2051)
   * [mod_redirect,mod_rewrite] short-circuit if blank replacement (fixes #2085)
+  * [mod_indexfile] save physical path to env (fixes #448, #892)
 
 - 1.4.39 - 2016-01-02
   * [core] fix memset_s call (fixes #2698)

--- a/NEWS
+++ b/NEWS
@@ -74,6 +74,7 @@ NEWS
   * [mod_dirlisting] class for dir <tr> (fixes #2304)
   * [core] define __STDC_WANT_LIB_EXT1__ (fixes #2722)
   * [core] setrlimit max-fds <= rlim_max for non-root (fixes #2723)
+  * [mod_ssi] config ssi.conditional-requests
 
 - 1.4.39 - 2016-01-02
   * [core] fix memset_s call (fixes #2698)

--- a/NEWS
+++ b/NEWS
@@ -79,6 +79,7 @@ NEWS
   * [mod_redirect,mod_rewrite] short-circuit if blank replacement (fixes #2085)
   * [mod_indexfile] save physical path to env (fixes #448, #892)
   * [core] open fd when appending file to cq (fixes #2655)
+  * [config] server.listen-backlog option (fixes #1825, #2116)
 
 - 1.4.39 - 2016-01-02
   * [core] fix memset_s call (fixes #2698)

--- a/NEWS
+++ b/NEWS
@@ -76,6 +76,7 @@ NEWS
   * [core] setrlimit max-fds <= rlim_max for non-root (fixes #2723)
   * [mod_ssi] config ssi.conditional-requests
   * [mod_ssi] config ssi.exec (fixes #2051)
+  * [mod_redirect,mod_rewrite] short-circuit if blank replacement (fixes #2085)
 
 - 1.4.39 - 2016-01-02
   * [core] fix memset_s call (fixes #2698)

--- a/doc/config/conf.d/ssi.conf
+++ b/doc/config/conf.d/ssi.conf
@@ -1,6 +1,6 @@
 #######################################################################
 ##
-##  Server Side Includes 
+##  Server Side Includes
 ## -----------------------
 ##
 ## See http://redmine.lighttpd.net/projects/lighttpd/wiki/Docs_ModSSI
@@ -11,6 +11,35 @@ server.modules += ( "mod_ssi" )
 ## which extensions should be ran through mod_ssi.
 ##
 ssi.extension              = ( ".shtml" )
+
+##
+## The  ssi.conditional-requests  directive only affects requests
+## handled by the SSI module and allows to declare which SSI pages
+## are cacheable and which are not. This directive can be enabled
+## or disabled globally and/or in any context.
+##
+## As the name of this directive suggests, conditional requests will
+## be handled appropriately for any SSI page for which the directive
+## is enabled. In particular, the "ETag" and "Last-Modified" headers
+## will both be sent. Conversely, these headers will NOT be sent for
+## pages for which the directive is disabled.
+##
+## The directive should be set to "enable" ONLY for requests that are
+## known to generate cacheable documents. An SSI page which only
+## includes contents from other static files and/or which uses SSI
+## commands that produce predictable output (e.g. the echo command
+## for the LAST_MODIFIED variable) is likely to be cacheable.
+##
+## The directive should be set to "disable" for ALL other documents,
+## that is, for SSI pages which depend on non-predictable input such
+## as (but not limited to) output from ssi exec commands, data from
+## the client's request headers (other than the request URI), or any
+## other non constant input such as the current date or time, the
+## client's user-agent, etc...
+##
+## Disabled by default.
+##
+#ssi.conditional-requests = "enable"
 
 ##
 #######################################################################

--- a/doc/config/lighttpd.conf
+++ b/doc/config/lighttpd.conf
@@ -207,6 +207,35 @@ server.network-backend = "sendfile"
 server.max-fds = 2048
 
 ##
+## listen-backlog is the size of the listen() backlog queue requested when
+## the lighttpd server ask the kernel to listen() on the provided network
+## address.  Clients attempting to connect() to the server enter the listen()
+## backlog queue and wait for the lighttpd server to accept() the connection.
+##
+## The out-of-box default on many operating systems is 128 and is identified
+## as SOMAXCONN.  This can be tuned on many operating systems.  (On Linux,
+## cat /proc/sys/net/core/somaxconn)  Requesting a size larger than operating
+## system limit will be silently reduced to the limit by the operating system.
+##
+## When there are too many connection attempts waiting for the server to
+## accept() new connections, the listen backlog queue fills and the kernel
+## rejects additional connection attempts.  This can be useful as an
+## indication to an upstream load balancer that the server is busy, and
+## possibly overloaded.  In that case, configure a smaller limit for
+## server.listen-backlog.  On the other hand, configure a larger limit to be
+## able to handle bursts of new connections, but only do so up to an amount
+## that the server can keep up with responding in a reasonable amount of
+## time.  Otherwise, clients may abandon the connection attempts and the
+## server will waste resources servicing abandoned connections.
+##
+## It is best to leave this setting at its default unless you have modelled
+## your traffic and tested that changing this benefits your traffic patterns.
+##
+## Default: 1024
+##
+#server.listen-backlog = 128
+
+##
 ## Stat() call caching.
 ##
 ## lighttpd can utilize FAM/Gamin to cache stat call.

--- a/src/base.h
+++ b/src/base.h
@@ -294,6 +294,7 @@ typedef struct {
 	unsigned short etag_use_size;
 	unsigned short force_lowercase_filenames; /* if the FS is case-insensitive, force all files to lower-case */
 	unsigned int max_request_size;
+	int listen_backlog;
 
 	unsigned short kbytes_per_second; /* connection kb/s limit */
 

--- a/src/chunk.c
+++ b/src/chunk.c
@@ -203,6 +203,27 @@ void chunkqueue_reset(chunkqueue *cq) {
 	cq->bytes_out = 0;
 }
 
+void chunkqueue_append_file_fd(chunkqueue *cq, buffer *fn, int fd, off_t offset, off_t len) {
+	chunk *c;
+
+	if (0 == len) {
+		close(fd);
+		return;
+	}
+
+	c = chunkqueue_get_unused_chunk(cq);
+
+	c->type = FILE_CHUNK;
+
+	buffer_copy_buffer(c->file.name, fn);
+	c->file.start = offset;
+	c->file.length = len;
+	c->file.fd = fd;
+	c->offset = 0;
+
+	chunkqueue_append_chunk(cq, c);
+}
+
 void chunkqueue_append_file(chunkqueue *cq, buffer *fn, off_t offset, off_t len) {
 	chunk *c;
 

--- a/src/chunk.h
+++ b/src/chunk.h
@@ -51,6 +51,7 @@ typedef struct {
 chunkqueue *chunkqueue_init(void);
 void chunkqueue_set_tempdirs(chunkqueue *cq, array *tempdirs, unsigned int upload_temp_file_size);
 void chunkqueue_append_file(chunkqueue *cq, buffer *fn, off_t offset, off_t len); /* copies "fn" */
+void chunkqueue_append_file_fd(chunkqueue *cq, buffer *fn, int fd, off_t offset, off_t len); /* copies "fn" */
 void chunkqueue_append_mem(chunkqueue *cq, const char *mem, size_t len); /* copies memory */
 void chunkqueue_append_buffer(chunkqueue *cq, buffer *mem); /* may reset "mem" */
 void chunkqueue_prepend_buffer(chunkqueue *cq, buffer *mem); /* may reset "mem" */

--- a/src/configfile.c
+++ b/src/configfile.c
@@ -111,6 +111,7 @@ static int config_insert(server *srv) {
 		{ "ssl.empty-fragments",               NULL, T_CONFIG_BOOLEAN, T_CONFIG_SCOPE_CONNECTION }, /* 67 */
 		{ "server.upload-temp-file-size",      NULL, T_CONFIG_INT,     T_CONFIG_SCOPE_SERVER     }, /* 68 */
 		{ "mimetype.xattr-name",               NULL, T_CONFIG_STRING,  T_CONFIG_SCOPE_SERVER     }, /* 69 */
+		{ "server.listen-backlog",             NULL, T_CONFIG_INT,     T_CONFIG_SCOPE_CONNECTION }, /* 70 */
 
 		{ "server.host",
 			"use server.bind instead",
@@ -229,6 +230,7 @@ static int config_insert(server *srv) {
 		s->ssl_verifyclient_depth = 9;
 		s->ssl_verifyclient_export_cert = 0;
 		s->ssl_disable_client_renegotiation = 1;
+		s->listen_backlog = (0 == i ? 1024 : srv->config_storage[0]->listen_backlog);
 
 		/* all T_CONFIG_SCOPE_CONNECTION options */
 		cv[2].destination = s->errorfile_prefix;
@@ -285,6 +287,7 @@ static int config_insert(server *srv) {
 		cv[65].destination = &(s->ssl_disable_client_renegotiation);
 		cv[66].destination = &(s->ssl_honor_cipher_order);
 		cv[67].destination = &(s->ssl_empty_fragments);
+		cv[70].destination = &(s->listen_backlog);
 
 		srv->config_storage[i] = s;
 
@@ -355,6 +358,7 @@ int config_setup_connection(server *srv, connection *con) {
 
 	PATCH(range_requests);
 	PATCH(force_lowercase_filenames);
+	/*PATCH(listen_backlog);*//*(not necessary; used only at startup)*/
 	PATCH(ssl_enabled);
 
 	PATCH(ssl_pemfile);
@@ -483,6 +487,10 @@ int config_patch_connection(server *srv, connection *con) {
 				PATCH(allow_http11);
 			} else if (buffer_is_equal_string(du->key, CONST_STR_LEN("server.force-lowercase-filenames"))) {
 				PATCH(force_lowercase_filenames);
+		      #if 0 /*(not necessary; used only at startup)*/
+			} else if (buffer_is_equal_string(du->key, CONST_STR_LEN("server.listen-backlog"))) {
+				PATCH(listen_backlog);
+		      #endif
 			} else if (buffer_is_equal_string(du->key, CONST_STR_LEN("server.kbytes-per-second"))) {
 				PATCH(global_kbytes_per_second);
 				PATCH(global_bytes_per_second_cnt);

--- a/src/connections.c
+++ b/src/connections.c
@@ -495,11 +495,11 @@ static int connection_handle_write_prepare(server *srv, connection *con) {
 			buffer_append_int(con->physical.path, con->http_status);
 			buffer_append_string_len(con->physical.path, CONST_STR_LEN(".html"));
 
-			if (HANDLER_ERROR != stat_cache_get_entry(srv, con, con->physical.path, &sce)) {
+			if (0 == http_chunk_append_file(srv, con, con->physical.path)) {
 				con->file_finished = 1;
-
-				http_chunk_append_file(srv, con, con->physical.path, 0, sce->st.st_size);
-				response_header_overwrite(srv, con, CONST_STR_LEN("Content-Type"), CONST_BUF_LEN(sce->content_type));
+				if (HANDLER_ERROR != stat_cache_get_entry(srv, con, con->physical.path, &sce)) {
+					response_header_overwrite(srv, con, CONST_STR_LEN("Content-Type"), CONST_BUF_LEN(sce->content_type));
+				}
 			}
 		}
 

--- a/src/http_chunk.h
+++ b/src/http_chunk.h
@@ -7,7 +7,8 @@
 
 void http_chunk_append_mem(server *srv, connection *con, const char * mem, size_t len); /* copies memory */
 void http_chunk_append_buffer(server *srv, connection *con, buffer *mem); /* may reset "mem" */
-void http_chunk_append_file(server *srv, connection *con, buffer *fn, off_t offset, off_t len); /* copies "fn" */
+int http_chunk_append_file(server *srv, connection *con, buffer *fn); /* copies "fn" */
+int http_chunk_append_file_range(server *srv, connection *con, buffer *fn, off_t offset, off_t len); /* copies "fn" */
 void http_chunk_close(server *srv, connection *con);
 
 #endif

--- a/src/mod_fastcgi.c
+++ b/src/mod_fastcgi.c
@@ -250,6 +250,8 @@ typedef struct {
 				       applications prefer SIGUSR1 while the
 				       rest of the world would use SIGTERM
 				       *sigh* */
+
+	int listen_backlog;
 } fcgi_extension_host;
 
 /*
@@ -991,7 +993,7 @@ static int fcgi_spawn_connection(server *srv,
 			return -1;
 		}
 
-		if (-1 == listen(fcgi_fd, 1024)) {
+		if (-1 == listen(fcgi_fd, host->listen_backlog)) {
 			log_error_write(srv, __FILE__, __LINE__, "ss",
 				"listen failed:", strerror(errno));
 			close(fcgi_fd);
@@ -1288,6 +1290,7 @@ SETDEFAULTS_FUNC(mod_fastcgi_set_defaults) {
 						{ "strip-request-uri",  NULL, T_CONFIG_STRING, T_CONFIG_SCOPE_CONNECTION },      /* 13 */
 						{ "kill-signal",        NULL, T_CONFIG_SHORT, T_CONFIG_SCOPE_CONNECTION },       /* 14 */
 						{ "fix-root-scriptname",   NULL, T_CONFIG_BOOLEAN, T_CONFIG_SCOPE_CONNECTION },  /* 15 */
+						{ "listen-backlog",    NULL, T_CONFIG_INT,   T_CONFIG_SCOPE_CONNECTION },        /* 16 */
 
 						{ NULL,                NULL, T_CONFIG_UNSET, T_CONFIG_SCOPE_UNSET }
 					};
@@ -1314,6 +1317,7 @@ SETDEFAULTS_FUNC(mod_fastcgi_set_defaults) {
 					host->allow_xsendfile = 0; /* handle X-LIGHTTPD-send-file */
 					host->kill_signal = SIGTERM;
 					host->fix_root_path_name = 0;
+					host->listen_backlog = 1024;
 
 					fcv[0].destination = host->host;
 					fcv[1].destination = host->docroot;
@@ -1333,6 +1337,7 @@ SETDEFAULTS_FUNC(mod_fastcgi_set_defaults) {
 					fcv[13].destination = host->strip_request_uri;
 					fcv[14].destination = &(host->kill_signal);
 					fcv[15].destination = &(host->fix_root_path_name);
+					fcv[16].destination = &(host->listen_backlog);
 
 					if (0 != config_insert_values_internal(srv, da_host->value, fcv, T_CONFIG_SCOPE_CONNECTION)) {
 						goto error;

--- a/src/mod_redirect.c
+++ b/src/mod_redirect.c
@@ -209,6 +209,10 @@ static handler_t mod_redirect_uri_handler(server *srv, connection *con, void *p_
 						"execution error while matching: ", n);
 				return HANDLER_ERROR;
 			}
+		} else if (0 == pattern_len) {
+			/* short-circuit if blank replacement pattern
+			 * (do not attempt to match against remaining redirect rules) */
+			return HANDLER_GO_ON;
 		} else {
 			const char **list;
 			size_t start;

--- a/src/mod_rewrite.c
+++ b/src/mod_rewrite.c
@@ -383,6 +383,10 @@ static handler_t process_rewrite_rules(server *srv, connection *con, plugin_data
 						"execution error while matching: ", n);
 				return HANDLER_ERROR;
 			}
+		} else if (0 == pattern_len) {
+			/* short-circuit if blank replacement pattern
+			 * (do not attempt to match against remaining rewrite rules) */
+			return HANDLER_GO_ON;
 		} else {
 			const char **list;
 			size_t start;

--- a/src/mod_scgi.c
+++ b/src/mod_scgi.c
@@ -223,6 +223,8 @@ typedef struct {
 
 	only if a process is killed max_id waits for the process itself
 	to die and decrements its afterwards */
+
+	int listen_backlog;
 } scgi_extension_host;
 
 /*
@@ -786,7 +788,7 @@ static int scgi_spawn_connection(server *srv,
 			return -1;
 		}
 
-		if (-1 == listen(scgi_fd, 1024)) {
+		if (-1 == listen(scgi_fd, host->listen_backlog)) {
 			log_error_write(srv, __FILE__, __LINE__, "ss",
 				"listen failed:", strerror(errno));
 			close(scgi_fd);
@@ -1053,6 +1055,7 @@ SETDEFAULTS_FUNC(mod_scgi_set_defaults) {
 						{ "bin-environment",   NULL, T_CONFIG_ARRAY, T_CONFIG_SCOPE_CONNECTION },        /* 11 */
 						{ "bin-copy-environment", NULL, T_CONFIG_ARRAY, T_CONFIG_SCOPE_CONNECTION },     /* 12 */
 						{ "fix-root-scriptname",  NULL, T_CONFIG_BOOLEAN, T_CONFIG_SCOPE_CONNECTION },   /* 13 */
+						{ "listen-backlog",    NULL, T_CONFIG_INT,   T_CONFIG_SCOPE_CONNECTION },        /* 14 */
 
 
 						{ NULL,                NULL, T_CONFIG_UNSET, T_CONFIG_SCOPE_UNSET }
@@ -1076,6 +1079,7 @@ SETDEFAULTS_FUNC(mod_scgi_set_defaults) {
 					df->idle_timeout = 60;
 					df->disable_time = 60;
 					df->fix_root_path_name = 0;
+					df->listen_backlog = 1024;
 
 					fcv[0].destination = df->host;
 					fcv[1].destination = df->docroot;
@@ -1093,6 +1097,7 @@ SETDEFAULTS_FUNC(mod_scgi_set_defaults) {
 					fcv[11].destination = df->bin_env;
 					fcv[12].destination = df->bin_env_copy;
 					fcv[13].destination = &(df->fix_root_path_name);
+					fcv[14].destination = &(df->listen_backlog);
 
 
 					if (0 != config_insert_values_internal(srv, da_host->value, fcv, T_CONFIG_SCOPE_CONNECTION)) {

--- a/src/mod_ssi.h
+++ b/src/mod_ssi.h
@@ -18,6 +18,7 @@ typedef struct {
 	array *ssi_extension;
 	buffer *content_type;
 	unsigned short conditional_requests;
+	unsigned short ssi_exec;
 } plugin_config;
 
 typedef struct {

--- a/src/mod_ssi.h
+++ b/src/mod_ssi.h
@@ -17,6 +17,7 @@
 typedef struct {
 	array *ssi_extension;
 	buffer *content_type;
+	unsigned short conditional_requests;
 } plugin_config;
 
 typedef struct {

--- a/src/mod_staticfile.c
+++ b/src/mod_staticfile.c
@@ -540,10 +540,12 @@ URIHANDLER_FUNC(mod_staticfile_subrequest) {
 	/* we add it here for all requests
 	 * the HEAD request will drop it afterwards again
 	 */
-	http_chunk_append_file(srv, con, con->physical.path, 0, sce->st.st_size);
-
-	con->http_status = 200;
-	con->file_finished = 1;
+	if (0 == sce->st.st_size || 0 == http_chunk_append_file(srv, con, con->physical.path)) {
+		con->http_status = 200;
+		con->file_finished = 1;
+	} else {
+		con->http_status = 403;
+	}
 
 	return HANDLER_FINISHED;
 }

--- a/src/network.c
+++ b/src/network.c
@@ -436,7 +436,7 @@ static int network_server_init(server *srv, buffer *host_token, specific_config 
 		goto error_free_socket;
 	}
 
-	if (-1 == listen(srv_socket->fd, 128 * 8)) {
+	if (-1 == listen(srv_socket->fd, s->listen_backlog)) {
 		log_error_write(srv, __FILE__, __LINE__, "ss", "listen failed: ", strerror(errno));
 		goto error_free_socket;
 	}

--- a/src/stat_cache.h
+++ b/src/stat_cache.h
@@ -9,6 +9,7 @@ void stat_cache_free(stat_cache *fc);
 
 handler_t stat_cache_get_entry(server *srv, connection *con, buffer *name, stat_cache_entry **fce);
 handler_t stat_cache_handle_fdevent(server *srv, void *_fce, int revent);
+int stat_cache_open_rdonly_fstat (server *srv, connection *con, buffer *name, struct stat *st);
 
 int stat_cache_trigger_cleanup(server *srv);
 #endif


### PR DESCRIPTION
See doc/config/lighttpd.conf for explanation of listen() backlog queue

Additionally, mod_fastcgi and mod_scgi backend servers can now also be
configured with separate listen-backlog settings per server

x-ref:
  "add server.listen-backlog option instead of hard-coded value (128 * 8) for listen()"
  https://redmine.lighttpd.net/issues/2116
  "Don't disable backend when overloaded"
  https://redmine.lighttpd.net/issues/1825