### PR TITLE
support IPv6 in $HTTP["remote-ip"] CIDR cond match

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -579,6 +579,16 @@ add_executable(test_base64
 )
 add_test(NAME test_base64 COMMAND test_base64)
 
+add_executable(test_configfile
+	test_configfile.c
+	buffer.c
+	array.c
+	data_string.c
+	keyvalue.c
+	log.c
+)
+add_test(NAME test_configfile COMMAND test_configfile)
+
 if(HAVE_PCRE_H)
 	target_link_libraries(lighttpd ${PCRE_LDFLAGS})
 	add_target_properties(lighttpd COMPILE_FLAGS ${PCRE_CFLAGS})
@@ -703,6 +713,8 @@ if(WITH_LIBUNWIND)
 	add_target_properties(test_buffer COMPILE_FLAGS ${LIBUNWIND_CFLAGS})
 	target_link_libraries(test_base64 ${LIBUNWIND_LDFLAGS})
 	add_target_properties(test_base64 COMPILE_FLAGS ${LIBUNWIND_CFLAGS})
+	target_link_libraries(test_configfile ${PCRE_LDFLAGS} ${LIBUNWIND_LDFLAGS})
+	add_target_properties(test_configfile COMPILE_FLAGS ${PCRE_CFLAGS} ${LIBUNWIND_CFLAGS})
 endif()
 
 if(NOT WIN32)

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,12 +1,13 @@
 AM_CFLAGS = $(FAM_CFLAGS) $(LIBUNWIND_CFLAGS)
 
-noinst_PROGRAMS=lemon proc_open test_buffer test_base64
+noinst_PROGRAMS=lemon proc_open test_buffer test_base64 test_configfile
 sbin_PROGRAMS=lighttpd lighttpd-angel
 LEMON=$(top_builddir)/src/lemon$(EXEEXT)
 
 TESTS=\
 	test_buffer$(EXEEXT) \
-	test_base64$(EXEEXT)
+	test_base64$(EXEEXT) \
+	test_configfile$(EXEEXT)
 
 lemon_SOURCES=lemon.c
 
@@ -304,6 +305,9 @@ test_buffer_LDADD = $(LIBUNWIND_LIBS)
 
 test_base64_SOURCES = test_base64.c base64.c buffer.c
 test_base64_LDADD = $(LIBUNWIND_LIBS)
+
+test_configfile_SOURCES = test_configfile.c buffer.c array.c data_string.c keyvalue.c log.c
+test_configfile_LDADD = $(PCRE_LIB) $(LIBUNWIND_LIBS)
 
 noinst_HEADERS   = $(hdr)
 EXTRA_DIST = \

--- a/src/test_configfile.c
+++ b/src/test_configfile.c
@@ -1,0 +1,87 @@
+#include "configfile-glue.c"
+
+#include <stdlib.h>
+#include <stdio.h>
+
+const struct {
+    const char *string;
+    const char *rmtstr;
+    int rmtfamily;
+    int expect;
+} rmtmask[] = {
+    { "1.0.0.1/1",          "1.0.0.1",         AF_INET, 1 }
+   ,{ "254.254.254.254/1",  "254.0.0.1",       AF_INET, 1 }
+   ,{ "254.254.254.252/31", "254.254.254.253", AF_INET, 1 }
+   ,{ "254.254.254.253/31", "254.254.254.254", AF_INET, 0 }
+   ,{ "254.254.254.253/32", "254.254.254.254", AF_INET, 0 }
+   ,{ "254.254.254.254/32", "254.254.254.254", AF_INET, 1 }
+  #ifdef HAVE_IPV6
+   ,{ "2001::/3",           "2001::1",         AF_INET6, 1 }
+   ,{ "2f01::/5",           "2701::1",         AF_INET6, 0 }
+   ,{ "2f01::/32",          "2f01::1",         AF_INET6, 1 }
+   ,{ "2f01::/32",          "2f02::1",         AF_INET6, 0 }
+   ,{ "2001::1/127",        "2001::1",         AF_INET6, 1 }
+   ,{ "2001::1/127",        "2001::2",         AF_INET6, 0 }
+   ,{ "2001::2/128",        "2001::2",         AF_INET6, 1 }
+   ,{ "2001::2/128",        "2001::3",         AF_INET6, 0 }
+   ,{ "1.0.0.1/1",          "::ffff:1.0.0.1",          AF_INET6, 1 }
+   ,{ "254.254.254.254/1",  "::ffff:254.0.0.1",        AF_INET6, 1 }
+   ,{ "254.254.254.252/31", "::ffff:254.254.254.253",  AF_INET6, 1 }
+   ,{ "254.254.254.253/31", "::ffff:254.254.254.254",  AF_INET6, 0 }
+   ,{ "254.254.254.253/32", "::ffff:254.254.254.254",  AF_INET6, 0 }
+   ,{ "254.254.254.254/32", "::ffff:254.254.254.254",  AF_INET6, 1 }
+   ,{ "::ffff:1.0.0.1/97",          "1.0.0.1",         AF_INET, 1 }
+   ,{ "::ffff:254.254.254.254/97",  "254.0.0.1",       AF_INET, 1 }
+   ,{ "::ffff:254.254.254.252/127", "254.254.254.253", AF_INET, 1 }
+   ,{ "::ffff:254.254.254.253/127", "254.254.254.254", AF_INET, 0 }
+   ,{ "::ffff:254.254.254.253/128", "254.254.254.254", AF_INET, 0 }
+   ,{ "::ffff:254.254.254.254/128", "254.254.254.254", AF_INET, 1 }
+  #endif
+};
+
+static void test_configfile_addrbuf_eq_remote_ip_mask (void) {
+	int i, m;
+	buffer * const s = buffer_init();
+	sock_addr rmt;
+
+	for (i = 0; i < (int)(sizeof(rmtmask)/sizeof(rmtmask[0])); ++i) {
+	      #ifndef HAVE_INET_PTON
+		rmt.ipv4.sin_family = AF_INET;
+		rmt.ipv4.sin_addr.s_addr = inet_addr(rmtmask[i].rmtstr);
+	      #else
+		if (rmtmask[i].rmtfamily == AF_INET) {
+			rmt.ipv4.sin_family = AF_INET;
+			inet_pton(AF_INET, rmtmask[i].rmtstr, &rmt.ipv4.sin_addr);
+		#ifdef HAVE_IPV6
+		} else if (rmtmask[i].rmtfamily == AF_INET6) {
+			rmt.ipv6.sin6_family = AF_INET6;
+			inet_pton(AF_INET6, rmtmask[i].rmtstr, &rmt.ipv6.sin6_addr);
+		#endif
+		} else {
+			continue;
+		}
+	      #endif
+		buffer_copy_string(s, rmtmask[i].string);
+		m = config_addrbuf_eq_remote_ip_mask(NULL,s,strchr(s->ptr,'/'),&rmt);
+		if (m != rmtmask[i].expect) {
+			fprintf(stderr, "failed assertion: %s %s %s\n",
+				rmtmask[i].string,
+				rmtmask[i].expect ? "==" : "!=",
+				rmtmask[i].rmtstr);
+			exit(-1);
+		}
+	}
+
+	buffer_free(s);
+}
+
+int main (void) {
+	test_configfile_addrbuf_eq_remote_ip_mask();
+
+	return 0;
+}
+
+/*
+ * stub functions (for linking)
+ */
+void fd_close_on_exec(int fd) { UNUSED(fd); };


### PR DESCRIPTION
x-ref:
  "Matching IPv6 addresses with $HTTP["remoteip"]"
  https://redmine.lighttpd.net/issues/2706