### PR TITLE
fallback to lseek()/read() if mmap() fails (#fixes 2666)

### DIFF
--- a/src/mod_cgi.c
+++ b/src/mod_cgi.c
@@ -738,7 +738,7 @@ static int cgi_write_file_chunk_mmap(server *srv, connection *con, int fd, chunk
 	off_t offset, toSend, file_end;
 	ssize_t r;
 	size_t mmap_offset, mmap_avail;
-	const char *data;
+	char *data;
 
 	force_assert(NULL != c);
 	force_assert(FILE_CHUNK == c->type);
@@ -769,21 +769,39 @@ static int cgi_write_file_chunk_mmap(server *srv, connection *con, int fd, chunk
 		c->file.mmap.length = file_end - c->file.mmap.offset;
 
 		if (MAP_FAILED == (c->file.mmap.start = mmap(NULL, c->file.mmap.length, PROT_READ, MAP_PRIVATE, c->file.fd, c->file.mmap.offset))) {
-			log_error_write(srv, __FILE__, __LINE__, "ssbdoo", "mmap failed:",
-				strerror(errno), c->file.name, c->file.fd, c->file.mmap.offset, (off_t) c->file.mmap.length);
-			return -1;
+			if (toSend > 65536) toSend = 65536;
+			data = malloc(toSend);
+			force_assert(data);
+			if (-1 == lseek(c->file.fd, offset, SEEK_SET)
+			    || 0 >= (toSend = read(c->file.fd, data, toSend))) {
+				if (-1 == toSend) {
+					log_error_write(srv, __FILE__, __LINE__, "ssbdo", "lseek/read failed:",
+						strerror(errno), c->file.name, c->file.fd, offset);
+				} else { /*(0 == toSend)*/
+					log_error_write(srv, __FILE__, __LINE__, "sbdo", "unexpected EOF (input truncated?):",
+						c->file.name, c->file.fd, offset);
+				}
+				free(data);
+				return -1;
+			}
 		}
 	}
 
-	force_assert(offset >= c->file.mmap.offset);
-	mmap_offset = offset - c->file.mmap.offset;
-	force_assert(c->file.mmap.length > mmap_offset);
-	mmap_avail = c->file.mmap.length - mmap_offset;
-	force_assert(toSend <= (off_t) mmap_avail);
+	if (MAP_FAILED != c->file.mmap.start) {
+		force_assert(offset >= c->file.mmap.offset);
+		mmap_offset = offset - c->file.mmap.offset;
+		force_assert(c->file.mmap.length > mmap_offset);
+		mmap_avail = c->file.mmap.length - mmap_offset;
+		force_assert(toSend <= (off_t) mmap_avail);
 
-	data = c->file.mmap.start + mmap_offset;
+		data = c->file.mmap.start + mmap_offset;
+	}
 
-	if ((r = write(fd, data, toSend)) < 0) {
+	r = write(fd, data, toSend);
+
+	if (MAP_FAILED == c->file.mmap.start) free(data);
+
+	if (r < 0) {
 		switch (errno) {
 		case EAGAIN:
 		case EINTR:

--- a/src/stream.h
+++ b/src/stream.h
@@ -7,6 +7,7 @@
 typedef struct {
 	char *start;
 	off_t size;
+	int mapped;
 } stream;
 
 int stream_open(stream *f, buffer *fn);


### PR DESCRIPTION
fallback to lseek()/read() if mmap() fails (#fixes 2666)
e.g. when mmap() is used on lighttpd-controlled temporary files
used POST request body (mod_cgi) and PUT file upload (mod_webdav)

replace use of stream_open() on potentially untrusted files
(protect against SIGBUS if a file is modified while map is read)
Note: stream.[ch] may be removed in a future release
For now, stream.[ch] will read entire file into memory if mmap fails
and so it should only be used on trusted files, e.g. config files.

http_auth basic and digest files are typically small and so buffered
stdio fopen(), fgets(), fclose() will likely be approximately as fast
as mmap.

mod_dirlisting header and readme files are typically small and so
open(), read(), close() will typically be approximately as fast as mmap

mod_ssi will likely be much faster, now buffering SSI page construction
rather than a potentially huge number of file open() calls, one for each
tiny chunk of text between SSI directives.

mod_webdav COPY and MOVE may be slower due to removal of mmap, but are
now more resilient to partial writes.

x-ref:
  "handle filesystems without mmap() support"
  https://redmine.lighttpd.net/issues/2666
  "WebDAV upload-> mmap failed: operation not permitted"
  https://redmine.lighttpd.net/issues/962
  "Lighttpd 1.4.20 Crash (SIGBUS in mod_compress)"
  https://redmine.lighttpd.net/issues/1879
  "Crash SIGBUS"
  https://redmine.lighttpd.net/issues/2391