### PR TITLE
[core] fallback to write if sendfile not supported (fixes #471, #987)

### DIFF
--- a/src/network_darwin_sendfile.c
+++ b/src/network_darwin_sendfile.c
@@ -46,6 +46,26 @@ int network_write_file_chunk_sendfile(server *srv, connection *con, int fd, chun
 		case EPIPE:
 		case ENOTCONN:
 			return -2;
+		case EINVAL:
+		case ENOSYS:
+	      #if defined(ENOTSUP) \
+		&& (!defined(EOPNOTSUPP) || EOPNOTSUPP != ENOTSUP)
+		case ENOTSUP:
+	      #endif
+	      #ifdef EOPNOTSUPP
+		case EOPNOTSUPP:
+	      #endif
+	      #ifdef ESOCKTNOSUPPORT
+		case ESOCKTNOSUPPORT:
+	      #endif
+	      #ifdef EAFNOSUPPORT
+		case EAFNOSUPPORT:
+	      #endif
+		      #ifdef USE_MMAP
+			return network_write_file_chunk_mmap(srv, con, fd, cq, p_max_bytes);
+		      #else
+			return network_write_file_chunk_no_mmap(srv, con, fd, cq, p_max_bytes);
+		      #endif
 		default:
 			log_error_write(srv, __FILE__, __LINE__, "ssd", "sendfile: ", strerror(errno), errno);
 			return -1;

--- a/src/network_freebsd_sendfile.c
+++ b/src/network_freebsd_sendfile.c
@@ -45,6 +45,26 @@ int network_write_file_chunk_sendfile(server *srv, connection *con, int fd, chun
 		case EPIPE:
 		case ENOTCONN:
 			return -2;
+		case EINVAL:
+		case ENOSYS:
+	      #if defined(ENOTSUP) \
+		&& (!defined(EOPNOTSUPP) || EOPNOTSUPP != ENOTSUP)
+		case ENOTSUP:
+	      #endif
+	      #ifdef EOPNOTSUPP
+		case EOPNOTSUPP:
+	      #endif
+	      #ifdef ESOCKTNOSUPPORT
+		case ESOCKTNOSUPPORT:
+	      #endif
+	      #ifdef EAFNOSUPPORT
+		case EAFNOSUPPORT:
+	      #endif
+		      #ifdef USE_MMAP
+			return network_write_file_chunk_mmap(srv, con, fd, cq, p_max_bytes);
+		      #else
+			return network_write_file_chunk_no_mmap(srv, con, fd, cq, p_max_bytes);
+		      #endif
 		default:
 			log_error_write(srv, __FILE__, __LINE__, "ssd", "sendfile: ", strerror(errno), errno);
 			return -1;

--- a/src/network_linux_sendfile.c
+++ b/src/network_linux_sendfile.c
@@ -41,6 +41,26 @@ int network_write_file_chunk_sendfile(server *srv, connection *con, int fd, chun
 		case EPIPE:
 		case ECONNRESET:
 			return -2;
+		case EINVAL:
+		case ENOSYS:
+	      #if defined(ENOTSUP) \
+		&& (!defined(EOPNOTSUPP) || EOPNOTSUPP != ENOTSUP)
+		case ENOTSUP:
+	      #endif
+	      #ifdef EOPNOTSUPP
+		case EOPNOTSUPP:
+	      #endif
+	      #ifdef ESOCKTNOSUPPORT
+		case ESOCKTNOSUPPORT:
+	      #endif
+	      #ifdef EAFNOSUPPORT
+		case EAFNOSUPPORT:
+	      #endif
+		      #ifdef USE_MMAP
+			return network_write_file_chunk_mmap(srv, con, fd, cq, p_max_bytes);
+		      #else
+			return network_write_file_chunk_no_mmap(srv, con, fd, cq, p_max_bytes);
+		      #endif
 		default:
 			log_error_write(srv, __FILE__, __LINE__, "ssd",
 					"sendfile failed:", strerror(errno), fd);

--- a/src/network_solaris_sendfilev.c
+++ b/src/network_solaris_sendfilev.c
@@ -56,6 +56,26 @@ int network_write_file_chunk_sendfile(server *srv, connection *con, int fd, chun
 		case EPIPE:
 		case ENOTCONN:
 			return -2;
+		case EINVAL:
+		case ENOSYS:
+	      #if defined(ENOTSUP) \
+		&& (!defined(EOPNOTSUPP) || EOPNOTSUPP != ENOTSUP)
+		case ENOTSUP:
+	      #endif
+	      #ifdef EOPNOTSUPP
+		case EOPNOTSUPP:
+	      #endif
+	      #ifdef ESOCKTNOSUPPORT
+		case ESOCKTNOSUPPORT:
+	      #endif
+	      #ifdef EAFNOSUPPORT
+		case EAFNOSUPPORT:
+	      #endif
+		      #ifdef USE_MMAP
+			return network_write_file_chunk_mmap(srv, con, fd, cq, p_max_bytes);
+		      #else
+			return network_write_file_chunk_no_mmap(srv, con, fd, cq, p_max_bytes);
+		      #endif
 		default:
 			log_error_write(srv, __FILE__, __LINE__, "ssd", "sendfile: ", strerror(errno), errno);
 			return -1;


### PR DESCRIPTION
x-ref:
  "sendfile backends do not fall back to write/writev if they are not supported by the kernel"
  https://redmine.lighttpd.net/issues/471
  "error:network_freebsd_sendfile.c.175"
  https://redmine.lighttpd.net/issues/987