### PR TITLE
ssl: add support for ssl.cadn-file

### DIFF
--- a/src/base.h
+++ b/src/base.h
@@ -278,6 +278,7 @@ typedef struct {
 	/* server wide */
 	buffer *ssl_pemfile;
 	buffer *ssl_ca_file;
+	buffer *ssl_cadn_file;
 	buffer *ssl_cipher_list;
 	buffer *ssl_dh_file;
 	buffer *ssl_ec_curve;

--- a/src/configfile.c
+++ b/src/configfile.c
@@ -119,6 +119,7 @@ static int config_insert(server *srv) {
 		{ "server.http-parseopt-host-strict",  NULL, T_CONFIG_BOOLEAN, T_CONFIG_SCOPE_SERVER     }, /* 73 */
 		{ "server.http-parseopt-host-normalize",NULL,T_CONFIG_BOOLEAN, T_CONFIG_SCOPE_SERVER     }, /* 74 */
 		{ "server.bsd-accept-filter",          NULL, T_CONFIG_STRING,  T_CONFIG_SCOPE_CONNECTION }, /* 75 */
+		{ "ssl.cadn-file",                     NULL, T_CONFIG_STRING,  T_CONFIG_SCOPE_CONNECTION }, /* 76 */
 
 		{ "server.host",
 			"use server.bind instead",
@@ -202,6 +203,7 @@ static int config_insert(server *srv) {
 		s->server_name   = buffer_init();
 		s->ssl_pemfile   = buffer_init();
 		s->ssl_ca_file   = buffer_init();
+		s->ssl_cadn_file = buffer_init();
 		s->error_handler = buffer_init();
 		s->error_handler_404 = buffer_init();
 		s->server_tag    = buffer_init();
@@ -310,6 +312,7 @@ static int config_insert(server *srv) {
 	       || defined(__OpenBSD__) || defined(__DragonflyBSD__)
 		cv[75].destination = s->bsd_accept_filter;
 	      #endif
+		cv[76].destination = s->ssl_cadn_file;
 
 		srv->config_storage[i] = s;
 
@@ -461,6 +464,7 @@ int config_setup_connection(server *srv, connection *con) {
 	PATCH(ssl_pemfile_pkey);
 #endif
 	PATCH(ssl_ca_file);
+	PATCH(ssl_cadn_file);
 #ifdef USE_OPENSSL
 	PATCH(ssl_ca_file_cert_names);
 #endif
@@ -536,6 +540,11 @@ int config_patch_connection(server *srv, connection *con) {
 #endif
 			} else if (buffer_is_equal_string(du->key, CONST_STR_LEN("ssl.ca-file"))) {
 				PATCH(ssl_ca_file);
+#ifdef USE_OPENSSL
+				PATCH(ssl_ca_file_cert_names);
+#endif
+			} else if (buffer_is_equal_string(du->key, CONST_STR_LEN("ssl.cadn-file"))) {
+				PATCH(ssl_cadn_file);
 #ifdef USE_OPENSSL
 				PATCH(ssl_ca_file_cert_names);
 #endif

--- a/src/network.c
+++ b/src/network.c
@@ -745,8 +745,15 @@ int network_init(server *srv) {
 			if (network_openssl_load_pemfile(srv, i)) return -1;
 		}
 
+		if (!buffer_string_is_empty(s->ssl_cadn_file)) {
+			s->ssl_ca_file_cert_names = SSL_load_client_CA_file(s->ssl_cadn_file->ptr);
+			if (NULL == s->ssl_ca_file_cert_names) {
+				log_error_write(srv, __FILE__, __LINE__, "ssb", "SSL:",
+						ERR_error_string(ERR_get_error(), NULL), s->ssl_cadn_file);
+			}
+		}
 
-		if (!buffer_string_is_empty(s->ssl_ca_file)) {
+		if (NULL == s->ssl_ca_file_cert_names && !buffer_string_is_empty(s->ssl_ca_file)) {
 			s->ssl_ca_file_cert_names = SSL_load_client_CA_file(s->ssl_ca_file->ptr);
 			if (NULL == s->ssl_ca_file_cert_names) {
 				log_error_write(srv, __FILE__, __LINE__, "ssb", "SSL:",

--- a/src/server.c
+++ b/src/server.c
@@ -347,6 +347,7 @@ static void server_free(server *srv) {
 			buffer_free(s->server_tag);
 			buffer_free(s->ssl_pemfile);
 			buffer_free(s->ssl_ca_file);
+			buffer_free(s->ssl_cadn_file);
 			buffer_free(s->ssl_cipher_list);
 			buffer_free(s->ssl_dh_file);
 			buffer_free(s->ssl_ec_curve);


### PR DESCRIPTION
If ssl.cadn-file is not set, fallback to ssl.ca-file.

The ssl.cadn-file option provides independent control of
the "certificate_authorities" field (see RFC 5246 section
7.4.4 Certificate Request) separate from the actual list
of trusted certificate authorities used for client
certificate verification.

It may be necessary to send a hint that includes the DN
of a non-root client CA in order to receive the correct
certificate from the client, but such a non-root CA really
does not belong in the trusted client root CA list.

Signed-off-by: Kyle J. McKay mackyle@gmail.com
