### PR TITLE
Make the use of accept-filters conditional.

### DIFF
--- a/src/base.h
+++ b/src/base.h
@@ -294,6 +294,7 @@ typedef struct {
 
 	unsigned short use_ipv6, set_v6only; /* set_v6only is only a temporary option */
 	unsigned short defer_accept;
+	unsigned short use_acceptfilter; /* Use SO_ACCEPTFILTER, limited to *BSD */
 	unsigned short ssl_enabled; /* only interesting for setting up listening sockets. don't use at runtime */
 	unsigned short allow_http11;
 	unsigned short etag_use_inode;

--- a/src/configfile.c
+++ b/src/configfile.c
@@ -118,6 +118,7 @@ static int config_insert(server *srv) {
 		{ "server.http-parseopt-header-strict",NULL, T_CONFIG_BOOLEAN, T_CONFIG_SCOPE_SERVER     }, /* 72 */
 		{ "server.http-parseopt-host-strict",  NULL, T_CONFIG_BOOLEAN, T_CONFIG_SCOPE_SERVER     }, /* 73 */
 		{ "server.http-parseopt-host-normalize",NULL,T_CONFIG_BOOLEAN, T_CONFIG_SCOPE_SERVER     }, /* 74 */
+		{ "server.use-acceptfilter",           NULL, T_CONFIG_BOOLEAN, T_CONFIG_SCOPE_CONNECTION }, /* 75 */
 
 		{ "server.host",
 			"use server.bind instead",
@@ -185,6 +186,7 @@ static int config_insert(server *srv) {
 	cv[72].destination = &(srv->srvconf.http_header_strict);
 	cv[73].destination = &(srv->srvconf.http_host_strict);
 	cv[74].destination = &(srv->srvconf.http_host_normalize);
+	cv[75].destination = &(s->use_acceptfilter);
 
 	srv->config_storage = calloc(1, srv->config_context->used * sizeof(specific_config *));
 
@@ -221,6 +223,11 @@ static int config_insert(server *srv) {
 		s->use_ipv6      = 0;
 		s->set_v6only    = 1;
 		s->defer_accept  = 0;
+#ifdef SO_ACCEPTFILTER
+		s->use_acceptfilter = 1;
+#else
+		s->use_acceptfilter = 0;
+#endif
 #ifdef HAVE_LSTAT
 		s->follow_symlink = 1;
 #endif

--- a/src/network.c
+++ b/src/network.c
@@ -448,7 +448,7 @@ static int network_server_init(server *srv, buffer *host_token, specific_config 
 			log_error_write(srv, __FILE__, __LINE__, "ss", "can't set TCP_DEFER_ACCEPT: ", strerror(errno));
 		}
 #endif
-	} else {
+	} else if (s->use_acceptfilter) {
 #ifdef SO_ACCEPTFILTER
 		/* FreeBSD accf_http filter */
 		struct accept_filter_arg afa;


### PR DESCRIPTION
We had a recent discussion about bad interactions between accept-filters and misbehaving clients in NetBSD. The patch makes the use of accept filters conditional under an option, the default behavior doesn't t change. 