### PR TITLE
[mod_fastcgi] FastCGI Authorizer support with FastCGI Responders (fixes #321, #322)

### DIFF
--- a/src/mod_fastcgi.c
+++ b/src/mod_fastcgi.c
@@ -1511,11 +1511,6 @@ SETDEFAULTS_FUNC(mod_fastcgi_set_defaults) {
 							host->mode = FCGI_RESPONDER;
 						} else if (strcmp(fcgi_mode->ptr, "authorizer") == 0) {
 							host->mode = FCGI_AUTHORIZER;
-							if (buffer_string_is_empty(host->docroot)) {
-								log_error_write(srv, __FILE__, __LINE__, "s",
-										"ERROR: docroot is required for authorizer mode.");
-								goto error;
-							}
 						} else {
 							log_error_write(srv, __FILE__, __LINE__, "sbs",
 									"WARNING: unknown fastcgi mode:",
@@ -2397,6 +2392,19 @@ range_success: ;
 		default:
 			break;
 		}
+
+		if (host->mode == FCGI_AUTHORIZER &&
+		    key_len > 9 &&
+		    0 == strncasecmp(key, CONST_STR_LEN("Variable-"))) {
+			data_string *ds;
+			if (NULL == (ds = (data_string *)array_get_unused_element(con->environment, TYPE_STRING))) {
+				ds = data_response_init();
+			}
+			buffer_copy_string_len(ds->key, key + 9, key_len - 9);
+			buffer_copy_string(ds->value, value);
+
+			array_insert_unique(con->environment, (data_unset *)ds);
+		}
 	}
 
 	if (have_sendfile2) {
@@ -3269,6 +3277,7 @@ static handler_t fcgi_recv_response(server *srv, handler_ctx *hctx) {
 	plugin_data *p    = hctx->plugin_data;
 
 	fcgi_proc *proc   = hctx->proc;
+	fcgi_extension *ext = hctx->ext;
 	fcgi_extension_host *host= hctx->host;
 
 		switch (fcgi_demux_response(srv, hctx)) {
@@ -3285,16 +3294,46 @@ static handler_t fcgi_recv_response(server *srv, handler_ctx *hctx) {
 				 * now to handle authorized request.
 				 */
 
-				buffer_copy_buffer(con->physical.doc_root, host->docroot);
-				buffer_copy_buffer(con->physical.basedir, host->docroot);
+				if (!buffer_is_empty(host->docroot)) {
+					buffer_copy_buffer(con->physical.doc_root, host->docroot);
+					buffer_copy_buffer(con->physical.basedir, host->docroot);
 
-				buffer_copy_buffer(con->physical.path, host->docroot);
-				buffer_append_string_buffer(con->physical.path, con->uri.path);
+					buffer_copy_buffer(con->physical.path, host->docroot);
+					buffer_append_string_buffer(con->physical.path, con->uri.path);
 
-				con->mode = DIRECT;/*(avoid changing con->state, con->http_status)*/
-				fcgi_connection_close(srv, hctx);
-				con->http_status = 0;
-				con->file_started = 1; /* fcgi_extension won't touch the request afterwards */
+					con->mode = DIRECT;/*(avoid changing con->state, con->http_status)*/
+					fcgi_connection_close(srv, hctx);
+					con->http_status = 0;
+					con->file_started = 1; /* fcgi_extension won't touch the request afterwards */
+				} else {
+					/* docroot was not set - restart the request so other handlers can catch it */
+					fcgi_connection_close(srv, hctx);
+
+					connection_response_reset(srv, con); /*(includes con->http_status = 0)*/
+					con->mode = DIRECT;
+
+					/* user was authorized, set the FastCGI authorizer flag */
+					data_string *authorizer_env = NULL;
+					if (NULL == (authorizer_env = (data_string *)array_get_unused_element(con->environment, TYPE_STRING))) {
+						authorizer_env = data_string_init();
+					}
+					buffer_copy_string(authorizer_env->key, "FastCGI-Authorizer");
+					buffer_copy_buffer(authorizer_env->value, ext->key);
+					array_insert_unique(con->environment, (data_unset *)authorizer_env);
+
+					/* don't do more than 6 loops here, that normally shouldn't happen */
+					if (++con->loops_per_request > 5) {
+						authorizer_env = (data_string *)array_get_element(con->environment, "FastCGI-Authorizer");
+						log_error_write(srv, __FILE__, __LINE__, "sb", "too many authorizer loops while processing request:", con->request.orig_uri);
+						if (NULL != authorizer_env) {
+							log_error_write(srv, __FILE__, __LINE__, "sb", "FastCGI-Authorizer: ", authorizer_env->value);
+						}
+						con->http_status = 500; /* Internal Server Error */
+						return HANDLER_FINISHED;
+					}
+
+					return HANDLER_COMEBACK;
+				}
 			} else {
 				/* we are done */
 				fcgi_connection_close(srv, hctx);
@@ -3489,6 +3528,8 @@ static handler_t fcgi_check_extension(server *srv, connection *con, void *p_d, i
 	fcgi_extension *extension = NULL;
 	fcgi_extension_host *host = NULL;
 
+	data_string *authorizer_env = (data_string *)array_get_element(con->environment, "FastCGI-Authorizer");
+
 	if (con->mode != DIRECT) return HANDLER_GO_ON;
 
 	/* Possibly, we processed already this request */
@@ -3551,6 +3592,27 @@ static handler_t fcgi_check_extension(server *srv, connection *con, void *p_d, i
 			fcgi_extension *ext = p->conf.exts->exts[k];
 
 			if (buffer_is_empty(ext->key)) continue;
+
+			/* do not reuse same authorizer, skip if it's in FastCGI-Authorizer env var */
+			if (NULL != authorizer_env) {
+				if (0 == strcmp(authorizer_env->value->ptr, ext->key->ptr)) continue;
+
+				buffer *ext_leading = buffer_init_string(", ");
+				buffer_append_string_buffer(ext_leading, ext->key);
+
+				buffer *ext_trailing = buffer_init_buffer(ext->key);
+				buffer_append_string(ext_trailing, ", ");
+
+				if (NULL != strstr(authorizer_env->value->ptr, ext_leading->ptr) ||
+				    NULL != strstr(authorizer_env->value->ptr, ext_trailing->ptr)) {
+					buffer_free(ext_leading);
+					buffer_free(ext_trailing);
+					continue;
+				} else {
+					buffer_free(ext_leading);
+					buffer_free(ext_trailing);
+				}
+			}
 
 			ct_len = buffer_string_length(ext->key);
 

--- a/tests/fastcgi-auth.conf
+++ b/tests/fastcgi-auth.conf
@@ -68,13 +68,21 @@ compress.filetype = (
 fastcgi.debug = 0
 fastcgi.server = (
 	"/" => (
-			"grisu" => (
+		"grisu" => (
 			"host" => "127.0.0.1",
 			"port" => 20000,
 			"bin-path" => env.SRCDIR + "/fcgi-auth",
 			"mode" => "authorizer",
-			"docroot" => env.SRCDIR + "/tmp/lighttpd/servers/www.example.org/pages/",
 			"check-local" => "disable",
+		),
+	),
+	".fcgi" => (
+		"grisu2" => (
+			"host" => "127.0.0.1",
+			"port" => 10000,
+			"bin-path" => env.SRCDIR + "/fcgi-responder",
+			"check-local" => "disable",
+			"max-procs" => 1,
 		),
 	),
 )

--- a/tests/fcgi-auth.c
+++ b/tests/fcgi-auth.c
@@ -19,8 +19,11 @@ int main (void) {
 		printf("Content-type: text/html\r\n");
 
 		if (((p = getenv("QUERY_STRING")) == NULL) ||
-		    strcmp(p, "ok") != 0) {
+		    (strcmp(p, "ok") != 0 && strcmp(p, "var") != 0)) {
 			printf("Status: 403 Forbidden\r\n\r\n");
+		} else if (((p = getenv("QUERY_STRING")) != NULL) || strcmp(p, "var") == 0) {
+			printf("Variable-LIGHTYTEST: LighttpdTestContent\r\n");
+			printf("\r\n");
 		} else {
 			printf("\r\n");
 			/* default Status is 200 - allow access */

--- a/tests/fcgi-auth.c
+++ b/tests/fcgi-auth.c
@@ -11,25 +11,18 @@
 #include <string.h>
 
 int main (void) {
-	char* p;
-
 	while (FCGI_Accept() >= 0) {
 		/* wait for fastcgi authorizer request */
+		char* p = getenv("QUERY_STRING");
 
-		printf("Content-type: text/html\r\n");
-
-		if (((p = getenv("QUERY_STRING")) == NULL) ||
-		    (strcmp(p, "ok") != 0 && strcmp(p, "var") != 0)) {
-			printf("Status: 403 Forbidden\r\n\r\n");
-		} else if (((p = getenv("QUERY_STRING")) != NULL) && strcmp(p, "var") == 0) {
-			printf("Variable-LIGHTYTEST: LighttpdTestContent\r\n");
-			printf("\r\n");
-		} else {
-			printf("\r\n");
-			/* default Status is 200 - allow access */
+		/* Status: 200 OK to allow access is implied when not included in response */
+		if (p != NULL && 0 == strcmp(p, "var")) {
+			printf("Variable-X-LIGHTTPD-FCGI-AUTH: LighttpdTestContent\r\n");
+		} else if (p == NULL || 0 != strcmp(p, "ok")) {
+			printf("Status: 403 Forbidden\r\n");
 		}
 
-		printf("foobar\r\n");
+		printf("\r\n");
 	}
 
 	return 0;

--- a/tests/fcgi-auth.c
+++ b/tests/fcgi-auth.c
@@ -21,7 +21,7 @@ int main (void) {
 		if (((p = getenv("QUERY_STRING")) == NULL) ||
 		    (strcmp(p, "ok") != 0 && strcmp(p, "var") != 0)) {
 			printf("Status: 403 Forbidden\r\n\r\n");
-		} else if (((p = getenv("QUERY_STRING")) != NULL) || strcmp(p, "var") == 0) {
+		} else if (((p = getenv("QUERY_STRING")) != NULL) && strcmp(p, "var") == 0) {
 			printf("Variable-LIGHTYTEST: LighttpdTestContent\r\n");
 			printf("\r\n");
 		} else {

--- a/tests/fcgi-responder.c
+++ b/tests/fcgi-responder.c
@@ -44,6 +44,10 @@ int main (void) {
 			printf("%s", getenv("PATH_INFO"));
 		} else if (0 == strcmp(p, "script_name")) {
 			printf("%s", getenv("SCRIPT_NAME"));
+		} else if (0 == strcmp(p, "var")) {
+			char *test = getenv("LIGHTYTEST");
+			if (test == NULL) test = "(no value)";
+			printf("%s", test);
 		} else {
 			printf("test123");
 		}

--- a/tests/fcgi-responder.c
+++ b/tests/fcgi-responder.c
@@ -45,9 +45,8 @@ int main (void) {
 		} else if (0 == strcmp(p, "script_name")) {
 			printf("%s", getenv("SCRIPT_NAME"));
 		} else if (0 == strcmp(p, "var")) {
-			char *test = getenv("LIGHTYTEST");
-			if (test == NULL) test = "(no value)";
-			printf("%s", test);
+			p = getenv("X_LIGHTTPD_FCGI_AUTH");
+			printf("%s", p ? p : "(no value)");
 		} else {
 			printf("test123");
 		}

--- a/tests/mod-fastcgi.t
+++ b/tests/mod-fastcgi.t
@@ -7,7 +7,7 @@ BEGIN {
 }
 
 use strict;
-use Test::More tests => 58;
+use Test::More tests => 60;
 use LightyTest;
 
 my $tf = LightyTest->new();
@@ -291,6 +291,23 @@ EOF
  );
 	$t->{RESPONSE} = [ { 'HTTP-Protocol' => 'HTTP/1.0', 'HTTP-Status' => 200 } ];
 	ok($tf->handle_http($t) == 0, 'FastCGI - Auth in subdirectory');
+
+	$t->{REQUEST}  = ( <<EOF
+GET /index.fcgi?varfail HTTP/1.0
+Host: www.example.org
+EOF
+ );
+	$t->{RESPONSE} = [ { 'HTTP-Protocol' => 'HTTP/1.0', 'HTTP-Status' => 403 } ];
+	ok($tf->handle_http($t) == 0, 'FastCGI - Auth Fail with FastCGI responder afterwards');
+
+	$t->{REQUEST}  = ( <<EOF
+GET /index.fcgi?var HTTP/1.0
+Host: www.example.org
+EOF
+ );
+	$t->{RESPONSE} = [ { 'HTTP-Protocol' => 'HTTP/1.0', 'HTTP-Status' => 200, 'HTTP-Content' => 'LighttpdTestContent' } ];
+	ok($tf->handle_http($t) == 0, 'FastCGI - Auth Success with Variable- to Env expansion');
+
 
 	ok($tf->stop_proc == 0, "Stopping lighttpd");
 }


### PR DESCRIPTION
As discussed in http://redmine.lighttpd.net/issues/322, I reworked the patch from scratch based on git-master.
I also changed the test FastCGI authorizer and responder as well as the test case to test the new behavior.

Changes from old patch:
- I save the fcgi-exts in in FastCGI-Authorizer env var instead of just a flag, so it's theoretically possible to configure and use more than one authorizer
- as advised by you, array search is now outside of the loop (that was stupid of me ;) ) and buffer->used isn't needed any longer

I tried to not hurt the performance - if you see place for improvements, please comment on the diff :)

TODO:
- [ ] Rewrite extension check to use |ext|

Regards,
Christoph (ckreutzer)