### PR TITLE
fix systemd setting same as lighttpd2.

### DIFF
--- a/doc/systemd/lighttpd.service
+++ b/doc/systemd/lighttpd.service
@@ -3,8 +3,11 @@ Description=Lighttpd Daemon
 After=network.target
 
 [Service]
+Type=simple
 ExecStartPre=/usr/sbin/lighttpd -t -f /etc/lighttpd/lighttpd.conf
 ExecStart=/usr/sbin/lighttpd -D -f /etc/lighttpd/lighttpd.conf
+ExecReload=/bin/kill -HUP $MAINPID
+Restart=on-failure
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Hi.

I fixed systemd setting file in `docs/systemd`.
I need `reload` command when `logrotate` lighttpd access log.
After `logrotate`, need to send signal to change file descriptor of log file.