### PR TITLE
[config] suggest inclusion of mod_geoip... before mod_ssi.

### DIFF
--- a/doc/config/conf.d/geoip.conf
+++ b/doc/config/conf.d/geoip.conf
@@ -16,7 +16,7 @@ server.modules += ( "mod_geoip" )
 ## mod_geoip will determine the database type automatically so if you
 ## enter GeoCity databse path it will load GeoCity Env.
 ##
-#geoip.db-filename = "/path/to/GeoCityLite.dat"
+#geoip.db-filename = "/path/to/GeoLiteCity.dat"
 
 ##
 ## If enabled, mod_geoip will load the database binary file to memory

--- a/doc/config/modules.conf
+++ b/doc/config/modules.conf
@@ -59,6 +59,11 @@ server.modules = (
 ##
 
 ##
+## mod_geoip
+##
+#include "conf.d/geoip.conf"
+
+##
 ## mod_ssi
 ##
 #include "conf.d/ssi.conf"


### PR DESCRIPTION
* In modules.conf, mod_geoip needs to be loaded before mod_ssi, otherwise GeoIP vars won't be available to SSI pages.
* In geoip.conf suggest GeoLiteCity.dat instead of GeoCityLite.dat.