### PR TITLE
[WIP] Add I2P support

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -847,6 +847,23 @@ if test x$ipv6 = xtrue; then
   fi
 fi
 
+dnl Check for I2P support
+
+AC_MSG_CHECKING(for I2P support)
+AC_ARG_ENABLE(i2p,
+ AC_HELP_STRING([--enable-i2p],[enable I2P support]),
+ [case "${enableval}" in
+   yes) i2p=true ;;
+    no) i2p=false ;;
+     *) AC_MSG_ERROR(bad value ${enableval} for --enable-i2p) ;;
+  esac],[i2p=false])
+AC_MSG_RESULT($enableval)
+
+if test x$i2p = xtrue; then
+  AC_DEFINE(HAVE_I2P,1,[Whether to enable I2P support])
+fi
+AM_CONDITIONAL(BUILD_WITH_I2P, test x$i2p = xtrue)
+
 # disable mmap by default; if a mmapped file gets truncated, the process gets a SIGBUS signal
 # on reading the truncated area which we can't handle (yet).
 # lighttpd may always use mmap with files it owns (created tmp files)
@@ -1018,6 +1035,13 @@ fi
 
 features="network-ipv6"
 if test "$ac_cv_ipv6_support" = yes; then
+	enable_feature="$enable_feature $features"
+else
+	disable_feature="$disable_feature $features"
+fi
+
+features="network-i2p"
+if test "x$i2p" = xtrue; then
 	enable_feature="$enable_feature $features"
 else
 	disable_feature="$disable_feature $features"

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -76,6 +76,7 @@ common_src=base64.c buffer.c log.c \
 	network_write_mmap.c network_write_no_mmap.c \
 	network_freebsd_sendfile.c network_writev.c \
 	network_solaris_sendfilev.c network_openssl.c \
+	network_i2p.c \
 	rand.c \
 	splaytree.c status_counter.c \
 	safe_memclear.c network_darwin_sendfile.c
@@ -84,7 +85,7 @@ src = server.c response.c connections.c network.c \
 	configfile.c configparser.c request.c proc_open.c
 
 if BUILD_WITH_I2P
-src += libsam3.c
+common_src += libsam3.c
 endif
 
 lib_LTLIBRARIES =

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -83,6 +83,10 @@ common_src=base64.c buffer.c log.c \
 src = server.c response.c connections.c network.c \
 	configfile.c configparser.c request.c proc_open.c
 
+if BUILD_WITH_I2P
+src += libsam3.c
+endif
+
 lib_LTLIBRARIES =
 
 if NO_RDYNAMIC
@@ -340,6 +344,10 @@ hdr = server.h base64.h buffer.h network.h log.h keyvalue.h \
 	safe_memclear.h splaytree.h proc_open.h status_counter.h \
 	mod_magnet_cache.h \
 	version.h
+
+if BUILD_WITH_I2P
+hdr += libsam3.h
+endif
 
 DEFS= @DEFS@ -DHAVE_VERSION_H -DLIBRARY_DIR="\"$(libdir)\"" -DSBIN_DIR="\"$(sbindir)\""
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -346,7 +346,7 @@ hdr = server.h base64.h buffer.h network.h log.h keyvalue.h \
 	version.h
 
 if BUILD_WITH_I2P
-hdr += libsam3.h
+hdr += libsam3.h i2p-base64.h
 endif
 
 DEFS= @DEFS@ -DHAVE_VERSION_H -DLIBRARY_DIR="\"$(libdir)\"" -DSBIN_DIR="\"$(sbindir)\""

--- a/src/base.h
+++ b/src/base.h
@@ -443,7 +443,6 @@ typedef struct {
 	buffer *dst_addr_buf;
 
 #ifdef HAVE_I2P
-	int reading_i2p_dest;
 	buffer *i2p_dest;
 	buffer *i2p_dest_hash;
 	buffer *i2p_dest_b32;
@@ -589,6 +588,13 @@ typedef struct {
 	double loadavg[3];
 } server_config;
 
+#ifdef HAVE_I2P
+typedef struct i2p_listener {
+	Sam3Connection *conn;
+	struct i2p_listener *next;
+} i2p_listener;
+#endif
+
 typedef struct server_socket {
 	sock_addr addr;
 	int       fd;
@@ -597,6 +603,7 @@ typedef struct server_socket {
 #ifdef HAVE_I2P
 	unsigned short is_i2p;
 	Sam3Session    i2p_ses;
+	struct i2p_listener *i2p_listeners;
 #endif
 
 	unsigned short is_ssl;

--- a/src/base.h
+++ b/src/base.h
@@ -591,6 +591,7 @@ typedef struct {
 #ifdef HAVE_I2P
 typedef struct i2p_listener {
 	Sam3Connection *conn;
+	int fde_ndx;
 	struct i2p_listener *next;
 } i2p_listener;
 #endif

--- a/src/base.h
+++ b/src/base.h
@@ -338,6 +338,10 @@ typedef struct {
 	buffer *bsd_accept_filter;
 #endif
 
+#ifdef HAVE_I2P
+	buffer *i2p_sam_nickname;
+#endif
+
 #ifdef USE_OPENSSL
 	SSL_CTX *ssl_ctx; /* not patched */
 	/* SNI per host: with COMP_SERVER_SOCKET, COMP_HTTP_SCHEME, COMP_HTTP_HOST */

--- a/src/base.h
+++ b/src/base.h
@@ -442,6 +442,13 @@ typedef struct {
 	sock_addr dst_addr;
 	buffer *dst_addr_buf;
 
+#ifdef HAVE_I2P
+	int reading_i2p_dest;
+	buffer *i2p_dest;
+	buffer *i2p_dest_hash;
+	buffer *i2p_dest_b32;
+#endif
+
 	/* request */
 	buffer *parse_request;
 	unsigned int parsed_response; /* bitfield which contains the important header-fields of the parsed response header */

--- a/src/base.h
+++ b/src/base.h
@@ -553,6 +553,11 @@ typedef struct {
 	unsigned short log_request_header_on_error;
 	unsigned short log_state_handling;
 
+#ifdef HAVE_I2P
+	buffer *i2p_sam_host;
+	unsigned short i2p_sam_port;
+#endif
+
 	enum { STAT_CACHE_ENGINE_UNSET,
 			STAT_CACHE_ENGINE_NONE,
 			STAT_CACHE_ENGINE_SIMPLE

--- a/src/base.h
+++ b/src/base.h
@@ -28,6 +28,11 @@
 #include "etag.h"
 
 
+#ifdef HAVE_I2P
+# include "libsam3.h"
+#endif
+
+
 #if defined HAVE_LIBSSL && defined HAVE_OPENSSL_SSL_H
 # define USE_OPENSSL
 # include <openssl/opensslconf.h>
@@ -571,6 +576,11 @@ typedef struct server_socket {
 	sock_addr addr;
 	int       fd;
 	int       fde_ndx;
+
+#ifdef HAVE_I2P
+	unsigned short is_i2p;
+	Sam3Session    i2p_ses;
+#endif
 
 	unsigned short is_ssl;
 

--- a/src/base.h
+++ b/src/base.h
@@ -556,6 +556,7 @@ typedef struct {
 #ifdef HAVE_I2P
 	buffer *i2p_sam_host;
 	unsigned short i2p_sam_port;
+	buffer *i2p_sam_keydir;
 #endif
 
 	enum { STAT_CACHE_ENGINE_UNSET,

--- a/src/configfile.c
+++ b/src/configfile.c
@@ -145,6 +145,20 @@ static int config_insert(server *srv) {
 		{ "server.stream-response-body",       NULL, T_CONFIG_SHORT,   T_CONFIG_SCOPE_CONNECTION }, /* 77 */
 		{ "server.max-request-field-size",     NULL, T_CONFIG_INT,     T_CONFIG_SCOPE_SERVER     }, /* 78 */
 
+#ifdef HAVE_I2P
+		{ "i2p.sam.host",                      NULL, T_CONFIG_STRING,  T_CONFIG_SCOPE_SERVER     }, /* 79 */
+		{ "i2p.sam.port",                      NULL, T_CONFIG_SHORT,   T_CONFIG_SCOPE_SERVER     }, /* 80 */
+#else
+		{ "i2p.sam.host",
+			"lighttpd has not been built with I2P support."
+			"Please remove i2p.sam.host from your config, or recompile with --enable-i2p.",
+			T_CONFIG_UNSUPPORTED, T_CONFIG_SCOPE_UNSET },
+		{ "i2p.sam.port",
+			"lighttpd has not been built with I2P support."
+			"Please remove i2p.sam.port from your config, or recompile with --enable-i2p.",
+			T_CONFIG_UNSUPPORTED, T_CONFIG_SCOPE_UNSET },
+#endif
+
 		{ NULL,                                NULL, T_CONFIG_UNSET,   T_CONFIG_SCOPE_UNSET      }
 	};
 
@@ -183,6 +197,11 @@ static int config_insert(server *srv) {
 	cv[73].destination = &(srv->srvconf.http_host_strict);
 	cv[74].destination = &(srv->srvconf.http_host_normalize);
 	cv[78].destination = &(srv->srvconf.max_request_field_size);
+
+#ifdef HAVE_I2P
+	cv[79].destination = srv->srvconf.i2p_sam_host;
+	cv[80].destination = &(srv->srvconf.i2p_sam_port);
+#endif
 
 	srv->config_storage = calloc(1, srv->config_context->used * sizeof(specific_config *));
 

--- a/src/configfile.c
+++ b/src/configfile.c
@@ -148,6 +148,7 @@ static int config_insert(server *srv) {
 #ifdef HAVE_I2P
 		{ "i2p.sam.host",                      NULL, T_CONFIG_STRING,  T_CONFIG_SCOPE_SERVER     }, /* 79 */
 		{ "i2p.sam.port",                      NULL, T_CONFIG_SHORT,   T_CONFIG_SCOPE_SERVER     }, /* 80 */
+		{ "i2p.sam.keydir",                    NULL, T_CONFIG_STRING,  T_CONFIG_SCOPE_SERVER     }, /* 81 */
 #else
 		{ "i2p.sam.host",
 			"lighttpd has not been built with I2P support."
@@ -156,6 +157,10 @@ static int config_insert(server *srv) {
 		{ "i2p.sam.port",
 			"lighttpd has not been built with I2P support."
 			"Please remove i2p.sam.port from your config, or recompile with --enable-i2p.",
+			T_CONFIG_UNSUPPORTED, T_CONFIG_SCOPE_UNSET },
+		{ "i2p.sam.keydir",
+			"lighttpd has not been built with I2P support."
+			"Please remove i2p.sam.keydir from your config, or recompile with --enable-i2p.",
 			T_CONFIG_UNSUPPORTED, T_CONFIG_SCOPE_UNSET },
 #endif
 
@@ -201,6 +206,7 @@ static int config_insert(server *srv) {
 #ifdef HAVE_I2P
 	cv[79].destination = srv->srvconf.i2p_sam_host;
 	cv[80].destination = &(srv->srvconf.i2p_sam_port);
+	cv[81].destination = srv->srvconf.i2p_sam_keydir;
 #endif
 
 	srv->config_storage = calloc(1, srv->config_context->used * sizeof(specific_config *));

--- a/src/configfile.c
+++ b/src/configfile.c
@@ -149,6 +149,7 @@ static int config_insert(server *srv) {
 		{ "i2p.sam.host",                      NULL, T_CONFIG_STRING,  T_CONFIG_SCOPE_SERVER     }, /* 79 */
 		{ "i2p.sam.port",                      NULL, T_CONFIG_SHORT,   T_CONFIG_SCOPE_SERVER     }, /* 80 */
 		{ "i2p.sam.keydir",                    NULL, T_CONFIG_STRING,  T_CONFIG_SCOPE_SERVER     }, /* 81 */
+		{ "i2p.sam.nickname",                  NULL, T_CONFIG_STRING,  T_CONFIG_SCOPE_CONNECTION }, /* 82 */
 #else
 		{ "i2p.sam.host",
 			"lighttpd has not been built with I2P support."
@@ -161,6 +162,10 @@ static int config_insert(server *srv) {
 		{ "i2p.sam.keydir",
 			"lighttpd has not been built with I2P support."
 			"Please remove i2p.sam.keydir from your config, or recompile with --enable-i2p.",
+			T_CONFIG_UNSUPPORTED, T_CONFIG_SCOPE_UNSET },
+		{ "i2p.sam.nickname",
+			"lighttpd has not been built with I2P support."
+			"Please remove i2p.sam.nickname from your config, or recompile with --enable-i2p.",
 			T_CONFIG_UNSUPPORTED, T_CONFIG_SCOPE_UNSET },
 #endif
 
@@ -276,6 +281,10 @@ static int config_insert(server *srv) {
 		s->stream_request_body = 0;
 		s->stream_response_body = 0;
 
+#ifdef HAVE_I2P
+		s->i2p_sam_nickname = buffer_init();
+#endif
+
 		/* all T_CONFIG_SCOPE_CONNECTION options */
 		cv[2].destination = s->errorfile_prefix;
 		cv[7].destination = s->server_tag;
@@ -340,6 +349,10 @@ static int config_insert(server *srv) {
 	      #endif
 		cv[76].destination = &(s->stream_request_body);
 		cv[77].destination = &(s->stream_response_body);
+
+#ifdef HAVE_I2P
+		cv[82].destination = s->i2p_sam_nickname;
+#endif
 
 		srv->config_storage[i] = s;
 

--- a/src/configparser.y
+++ b/src/configparser.y
@@ -629,7 +629,8 @@ context ::= DOLLAR SRVVARNAME(B) LBRACKET stringop(C) RBRACKET cond(E) expressio
       else if (COMP_SERVER_SOCKET == dc->comp) {
         /*(redundant with parsing in network.c; not actually required here)*/
         if (rvalue->ptr[0] != ':' /*(network.c special-cases ":" and "[]")*/
-            && !(rvalue->ptr[0] == '[' && rvalue->ptr[1] == ']')) {
+            && !(rvalue->ptr[0] == '[' && rvalue->ptr[1] == ']')
+            && strncmp(rvalue->ptr, "i2p:", 4) != 0) {
           if (http_request_host_normalize(rvalue)) {
             fprintf(stderr, "invalid IP addr: %s\n", rvalue->ptr);
             ctx->ok = 0;

--- a/src/connections-glue.c
+++ b/src/connections-glue.c
@@ -10,6 +10,7 @@
 #ifdef USE_OPENSSL
 # include <openssl/ssl.h>
 # include <openssl/err.h>
+# include <openssl/sha.h>
 #endif
 
 const char *connection_get_state(connection_state_t state) {
@@ -225,6 +226,47 @@ int connection_handle_read(server *srv, connection *con) {
 	char *mem = NULL;
 	size_t mem_len = 0;
 	int toread;
+
+#ifdef HAVE_I2P
+	if (con->srv_socket->is_i2p && con->reading_i2p_dest) {
+		/* Read the first line, containing the remote Destination, before anything else happens */
+		char cur[2];
+		while (con->reading_i2p_dest && (1 == read(con->fd, cur, 1))) {
+			if (cur[0] == '\n') {
+				con->reading_i2p_dest = 0;
+			} else if (cur[0] == ' ') {
+				/* Not an I2P Destination -> not via SAM */
+				log_error_write(srv, __FILE__, __LINE__, "s", "Non-I2P request received on I2P socket");
+				connection_set_state(srv, con, CON_STATE_ERROR);
+				return -1;
+			} else {
+				buffer_append_string_len(con->i2p_dest, cur, 1);
+			}
+		}
+		if (con->reading_i2p_dest) {
+			return 0;
+#ifdef USE_OPENSSL
+		} else {
+			/* Calculate hash */
+			int raw_dest_len;
+			unsigned char *raw_dest = i2p_unbase64(con->i2p_dest->ptr, strlen(con->i2p_dest->ptr), &raw_dest_len);
+			unsigned char *hash = SHA256(raw_dest, raw_dest_len, 0);
+			free(raw_dest);
+			unsigned char *hash_b64 = i2p_base64(hash, strlen(hash), &raw_dest_len);
+			buffer_copy_string(con->i2p_dest_hash, hash_b64);
+			free(hash_b64);
+
+			/* Calculate B32 */
+			char b32_hash[56];
+			sam3Base32Encode(b32_hash, hash, strlen(hash));
+			char *eq_pos = strchrnul(b32_hash, '=');
+			eq_pos[0] = '\0';
+			buffer_copy_string(con->i2p_dest_b32, b32_hash);
+			buffer_append_string_len(con->i2p_dest_b32, CONST_STR_LEN(".b32.i2p"));
+#endif
+		}
+	}
+#endif
 
 	if (con->srv_socket->is_ssl) {
 		return connection_handle_read_ssl(srv, con);

--- a/src/connections.c
+++ b/src/connections.c
@@ -611,6 +611,11 @@ connection *connection_init(server *srv) {
 
 	CLEAN(server_name);
 	CLEAN(dst_addr_buf);
+#ifdef HAVE_I2P
+	CLEAN(i2p_dest);
+	CLEAN(i2p_dest_hash);
+	CLEAN(i2p_dest_b32);
+#endif
 #if defined USE_OPENSSL && ! defined OPENSSL_NO_TLSEXT
 	CLEAN(tlsext_server_name);
 #endif
@@ -677,6 +682,11 @@ void connections_free(server *srv) {
 
 		CLEAN(server_name);
 		CLEAN(dst_addr_buf);
+#ifdef HAVE_I2P
+		CLEAN(i2p_dest);
+		CLEAN(i2p_dest_hash);
+		CLEAN(i2p_dest_b32);
+#endif
 #if defined USE_OPENSSL && ! defined OPENSSL_NO_TLSEXT
 		CLEAN(tlsext_server_name);
 #endif
@@ -1074,6 +1084,15 @@ connection *connection_accepted(server *srv, server_socket *srv_socket, sock_add
 		srv->con_opened++;
 
 		con = connections_get_new_connection(srv);
+
+#ifdef HAVE_I2P
+		if (srv_socket->is_i2p) {
+			con->reading_i2p_dest = 1;
+			buffer_reset(con->i2p_dest);
+			buffer_reset(con->i2p_dest_hash);
+			buffer_reset(con->i2p_dest_b32);
+		}
+#endif
 
 		con->fd = cnt;
 		con->fde_ndx = -1;

--- a/src/connections.c
+++ b/src/connections.c
@@ -1038,7 +1038,7 @@ connection *connection_accept(server *srv, server_socket *srv_socket) {
 
 #ifdef HAVE_I2P
 	if (srv_socket->is_i2p) {
-		cnt = accept_i2p(srv_socket, (struct sockaddr *) &cnt_addr, &cnt_len);
+		cnt = accept_i2p(srv, srv_socket, (struct sockaddr *) &cnt_addr, &cnt_len);
 	} else {
 #endif
 #if defined(SOCK_CLOEXEC) && defined(SOCK_NONBLOCK)

--- a/src/i2p-base64.h
+++ b/src/i2p-base64.h
@@ -1,0 +1,186 @@
+/*
+
+  https://github.com/superwills/NibbleAndAHalf
+  base64.h -- Fast base64 encoding and decoding.
+  version 1.0.0, April 17, 2013 143a
+  Modified by str4d in 2015 to use the I2P standard base 64 alphabet
+
+  Copyright (C) 2013 William Sherif
+
+  This software is provided 'as-is', without any express or implied
+  warranty.  In no event will the authors be held liable for any damages
+  arising from the use of this software.
+
+  Permission is granted to anyone to use this software for any purpose,
+  including commercial applications, and to alter it and redistribute it
+  freely, subject to the following restrictions:
+
+  1. The origin of this software must not be misrepresented; you must not
+     claim that you wrote the original software. If you use this software
+     in a product, an acknowledgment in the product documentation would be
+     appreciated but is not required.
+  2. Altered source versions must be plainly marked as such, and must not be
+     misrepresented as being the original software.
+  3. This notice may not be removed or altered from any source distribution.
+
+  William Sherif
+  will.sherif@gmail.com
+
+  YWxsIHlvdXIgYmFzZSBhcmUgYmVsb25nIHRvIHVz
+
+*/
+#ifndef I2P_BASE64_H
+#define I2P_BASE64_H
+
+#include <stdio.h>
+#include <stdlib.h>
+
+// NON-I2P
+//const static char* b64="ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/" ;
+// I2P
+const static char* b64="ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-~" ;
+
+// maps A=>0,B=>1..
+const static unsigned char unb64[]={
+  0,   0,   0,   0,   0,   0,   0,   0,   0,   0, //10
+  0,   0,   0,   0,   0,   0,   0,   0,   0,   0, //20
+  0,   0,   0,   0,   0,   0,   0,   0,   0,   0, //30
+  0,   0,   0,   0,   0,   0,   0,   0,   0,   0, //40
+//0,   0,   0,  62,   0,   0,   0,  63,  52,  53, //50 NON-I2P
+  0,   0,   0,   0,   0,  62,   0,   0,  52,  53, //50 I2P (46 is '-')
+ 54,  55,  56,  57,  58,  59,  60,  61,   0,   0, //60
+  0,   0,   0,   0,   0,   0,   1,   2,   3,   4, //70
+  5,   6,   7,   8,   9,  10,  11,  12,  13,  14, //80
+ 15,  16,  17,  18,  19,  20,  21,  22,  23,  24, //90
+ 25,   0,   0,   0,   0,   0,   0,  26,  27,  28, //100
+ 29,  30,  31,  32,  33,  34,  35,  36,  37,  38, //110
+ 39,  40,  41,  42,  43,  44,  45,  46,  47,  48, //120
+//49, 50,  51,   0,   0,   0,   0,   0,   0,   0, //130 NON-I2P
+ 49,  50,  51,   0,   0,   0,  63,   0,   0,   0, //130 I2P (127 is '~')
+  0,   0,   0,   0,   0,   0,   0,   0,   0,   0, //140
+  0,   0,   0,   0,   0,   0,   0,   0,   0,   0, //150
+  0,   0,   0,   0,   0,   0,   0,   0,   0,   0, //160
+  0,   0,   0,   0,   0,   0,   0,   0,   0,   0, //170
+  0,   0,   0,   0,   0,   0,   0,   0,   0,   0, //180
+  0,   0,   0,   0,   0,   0,   0,   0,   0,   0, //190
+  0,   0,   0,   0,   0,   0,   0,   0,   0,   0, //200
+  0,   0,   0,   0,   0,   0,   0,   0,   0,   0, //210
+  0,   0,   0,   0,   0,   0,   0,   0,   0,   0, //220
+  0,   0,   0,   0,   0,   0,   0,   0,   0,   0, //230
+  0,   0,   0,   0,   0,   0,   0,   0,   0,   0, //240
+  0,   0,   0,   0,   0,   0,   0,   0,   0,   0, //250
+  0,   0,   0,   0,   0,   0,
+}; // This array has 255 elements
+
+// Converts binary data of length=len to base64 characters.
+// Length of the resultant string is stored in flen
+// (you must pass pointer flen).
+char* i2p_base64( const void* binaryData, int len, int *flen )
+{
+  const unsigned char* bin = (const unsigned char*) binaryData ;
+  char* res ;
+
+  int rc = 0 ; // result counter
+  int byteNo ; // I need this after the loop
+
+  int modulusLen = len % 3 ;
+  int pad = ((modulusLen&1)<<1) + ((modulusLen&2)>>1) ; // 2 gives 1 and 1 gives 2, but 0 gives 0.
+
+  *flen = 4*(len + pad)/3 ;
+  res = (char*) malloc( *flen + 1 ) ; // and one for the null
+  if( !res )
+  {
+    puts( "ERROR: base64 could not allocate enough memory." ) ;
+    puts( "I must stop because I could not get enough" ) ;
+    return 0;
+  }
+
+  for( byteNo = 0 ; byteNo <= len-3 ; byteNo+=3 )
+  {
+    unsigned char BYTE0=bin[byteNo];
+    unsigned char BYTE1=bin[byteNo+1];
+    unsigned char BYTE2=bin[byteNo+2];
+    res[rc++]  = b64[ BYTE0 >> 2 ] ;
+    res[rc++]  = b64[ ((0x3&BYTE0)<<4) + (BYTE1 >> 4) ] ;
+    res[rc++]  = b64[ ((0x0f&BYTE1)<<2) + (BYTE2>>6) ] ;
+    res[rc++]  = b64[ 0x3f&BYTE2 ] ;
+  }
+
+  if( pad==2 )
+  {
+    res[rc++] = b64[ bin[byteNo] >> 2 ] ;
+    res[rc++] = b64[ (0x3&bin[byteNo])<<4 ] ;
+    res[rc++] = '=';
+    res[rc++] = '=';
+  }
+  else if( pad==1 )
+  {
+    res[rc++]  = b64[ bin[byteNo] >> 2 ] ;
+    res[rc++]  = b64[ ((0x3&bin[byteNo])<<4)   +   (bin[byteNo+1] >> 4) ] ;
+    res[rc++]  = b64[ (0x0f&bin[byteNo+1])<<2 ] ;
+    res[rc++] = '=';
+  }
+
+  res[rc]=0; // NULL TERMINATOR! ;)
+  return res ;
+}
+
+unsigned char* i2p_unbase64( const char* ascii, int len, int *flen )
+{
+  const unsigned char *safeAsciiPtr = (const unsigned char*)ascii ;
+  unsigned char *bin ;
+  int cb=0;
+  int charNo;
+  int pad = 0 ;
+
+  if( len < 2 ) { // 2 accesses below would be OOB.
+    // catch empty string, return NULL as result.
+    puts( "ERROR: You passed an invalid base64 string (too short). You get NULL back." ) ;
+    *flen=0;
+    return 0 ;
+  }
+  if( safeAsciiPtr[ len-1 ]=='=' )  ++pad ;
+  if( safeAsciiPtr[ len-2 ]=='=' )  ++pad ;
+
+  *flen = 3*len/4 - pad ;
+  bin = (unsigned char*)malloc( *flen ) ;
+  if( !bin )
+  {
+    puts( "ERROR: unbase64 could not allocate enough memory." ) ;
+    puts( "I must stop because I could not get enough" ) ;
+    return 0;
+  }
+
+  for( charNo=0; charNo <= len - 4 - pad ; charNo+=4 )
+  {
+    int A=unb64[safeAsciiPtr[charNo]];
+    int B=unb64[safeAsciiPtr[charNo+1]];
+    int C=unb64[safeAsciiPtr[charNo+2]];
+    int D=unb64[safeAsciiPtr[charNo+3]];
+
+    bin[cb++] = (A<<2) | (B>>4) ;
+    bin[cb++] = (B<<4) | (C>>2) ;
+    bin[cb++] = (C<<6) | (D) ;
+  }
+
+  if( pad==1 )
+  {
+    int A=unb64[safeAsciiPtr[charNo]];
+    int B=unb64[safeAsciiPtr[charNo+1]];
+    int C=unb64[safeAsciiPtr[charNo+2]];
+
+    bin[cb++] = (A<<2) | (B>>4) ;
+    bin[cb++] = (B<<4) | (C>>2) ;
+  }
+  else if( pad==2 )
+  {
+    int A=unb64[safeAsciiPtr[charNo]];
+    int B=unb64[safeAsciiPtr[charNo+1]];
+
+    bin[cb++] = (A<<2) | (B>>4) ;
+  }
+
+  return bin ;
+}
+
+#endif

--- a/src/network.c
+++ b/src/network.c
@@ -184,8 +184,10 @@ static int network_server_init(server *srv, buffer *host_token, specific_config 
 	unsigned int port = 0;
 	const char *i2p_keyfile;
 	char *hp;
+#ifdef HAVE_I2P
 	FILE *fl;
 	char i2p_keybuffer[SAM3_PRIVKEY_SIZE+1];
+#endif
 	const char *host;
 	buffer *b;
 	int err;
@@ -245,15 +247,15 @@ static int network_server_init(server *srv, buffer *host_token, specific_config 
 			fclose(fl);
 
 			log_error_write(srv, __FILE__, __LINE__, "ss", "Creating SAMv3 session with Destination from", i2p_keyfile);
-			if (sam3CreateSession(&(srv_socket->i2p_ses), SAM3_HOST_DEFAULT, SAM3_PORT_DEFAULT, i2p_keybuffer, SAM3_SESSION_STREAM, NULL) < 0) {
-				log_error_write(srv, __FILE__, __LINE__, "ss", "SAMv3 create session failed:", strerror(errno));
+			if (sam3CreateSession(&(srv_socket->i2p_ses), srv->srvconf.i2p_sam_host, srv->srvconf.i2p_sam_port, i2p_keybuffer, SAM3_SESSION_STREAM, NULL) < 0) {
+				log_error_write(srv, __FILE__, __LINE__, "ss", "SAMv3 SESSION CREATE failed:", strerror(errno));
 				goto error_free_socket;
 			}
 		} else {
 			/* No file, so open a transient SAMv3 session and save its key */
 			log_error_write(srv, __FILE__, __LINE__, "s", "Creating SAMv3 session with new Destination");
-			if (sam3CreateSession(&(srv_socket->i2p_ses), SAM3_HOST_DEFAULT, SAM3_PORT_DEFAULT, SAM3_DESTINATION_TRANSIENT, SAM3_SESSION_STREAM, NULL) < 0) {
-				log_error_write(srv, __FILE__, __LINE__, "ss", "SAMv3 create session failed:", strerror(errno));
+			if (sam3CreateSession(&(srv_socket->i2p_ses), srv->srvconf.i2p_sam_host, srv->srvconf.i2p_sam_port, SAM3_DESTINATION_TRANSIENT, SAM3_SESSION_STREAM, NULL) < 0) {
+				log_error_write(srv, __FILE__, __LINE__, "ss", "SAMv3 SESSION CREATE failed:", strerror(errno));
 				goto error_free_socket;
 			}
 
@@ -326,7 +328,7 @@ static int network_server_init(server *srv, buffer *host_token, specific_config 
 	if (srv_socket->is_i2p) {
 		/* Set up the stream (the listener will be opened below) */
 		if (sam3StreamForward(&(srv_socket->i2p_ses), host, port) < 0) {
-			log_error_write(srv, __FILE__, __LINE__, "ss", "SAMv3 stream forward failed:", strerror(errno));
+			log_error_write(srv, __FILE__, __LINE__, "ss", "SAMv3 STREAM FORWARD failed:", strerror(errno));
 			goto error_free_socket;
 		}
 	}

--- a/src/network.c
+++ b/src/network.c
@@ -275,6 +275,7 @@ static int network_server_init(server *srv, buffer *host_token, specific_config 
 				log_error_write(srv, __FILE__, __LINE__, "ss", "SAMv3 SESSION CREATE failed:", strerror(errno));
 				goto error_free_socket;
 			}
+			log_error_write(srv, __FILE__, __LINE__, "s", "Session built");
 		} else {
 			/* No file, so open a transient SAMv3 session and save its key */
 			log_error_write(srv, __FILE__, __LINE__, "sss", "Creating SAMv3 session for", i2p_keyname, "with new Destination");
@@ -282,6 +283,7 @@ static int network_server_init(server *srv, buffer *host_token, specific_config 
 				log_error_write(srv, __FILE__, __LINE__, "ss", "SAMv3 SESSION CREATE failed:", strerror(errno));
 				goto error_free_socket;
 			}
+			log_error_write(srv, __FILE__, __LINE__, "s", "Session built");
 
 			if ((fl = fopen(kb->ptr, "wt")) != NULL) {
 				fwrite(srv_socket->i2p_ses.privkey, strlen(srv_socket->i2p_ses.privkey), 1, fl);
@@ -294,14 +296,14 @@ static int network_server_init(server *srv, buffer *host_token, specific_config 
 		buffer_free(ob);
 		buffer_free(kb);
 
-		/* Update pubkey file with current Destination */
+		/* Export current Destination */
 		kb = buffer_init();
 		if (!buffer_is_empty(srv->srvconf.i2p_sam_keydir)) {
 			buffer_copy_buffer(kb, srv->srvconf.i2p_sam_keydir);
 			buffer_append_string_len(kb, CONST_STR_LEN("/"));
 		}
 		buffer_append_string(kb, i2p_keyname);
-		buffer_append_string_len(kb, CONST_STR_LEN(".pubkey"));
+		buffer_append_string_len(kb, CONST_STR_LEN(".b64.txt"));
 		if (!buffer_is_empty(srv->srvconf.i2p_sam_keydir)) {
 			buffer_path_simplify(kb, kb);
 		}
@@ -309,9 +311,9 @@ static int network_server_init(server *srv, buffer *host_token, specific_config 
 		if ((fl = fopen(kb->ptr, "wt")) != NULL) {
 			fwrite(srv_socket->i2p_ses.pubkey, strlen(srv_socket->i2p_ses.pubkey), 1, fl);
 			fclose(fl);
-			log_error_write(srv, __FILE__, __LINE__, "ss", "Session built. Destination saved to", kb->ptr);
+			log_error_write(srv, __FILE__, __LINE__, "ss", "Destination B64 saved to", kb->ptr);
 		} else {
-			log_error_write(srv, __FILE__, __LINE__, "ss", "WARNING: Could not save Destination to", kb->ptr);
+			log_error_write(srv, __FILE__, __LINE__, "ss", "WARNING: Could not save Destination B64 to", kb->ptr);
 		}
 		buffer_free(kb);
 #else

--- a/src/network.c
+++ b/src/network.c
@@ -245,8 +245,14 @@ static int network_server_init(server *srv, buffer *host_token, specific_config 
 
 		/* Prepare SAM options */
 		ob = buffer_init();
-		buffer_copy_string_len(ob, CONST_STR_LEN("inbound.nickname=lighttpd-"));
-		buffer_append_string(ob, i2p_keyname);
+		if (!buffer_is_empty(s->i2p_sam_nickname)) {
+			buffer_copy_string_len(ob, CONST_STR_LEN("inbound.nickname=\""));
+			buffer_append_string_buffer(ob, s->i2p_sam_nickname);
+			buffer_append_string_len(ob, CONST_STR_LEN("\""));
+		} else {
+			buffer_copy_string_len(ob, CONST_STR_LEN("inbound.nickname=lighttpd-"));
+			buffer_append_string(ob, i2p_keyname);
+		}
 
 		/* Read in the Destination */
 		kb = buffer_init();

--- a/src/network.c
+++ b/src/network.c
@@ -1175,6 +1175,13 @@ int network_init(server *srv) {
 	return 0;
 }
 
+#ifdef HAVE_I2P
+int network_register_i2p_fdevent(server *srv, server_socket *srv_socket, i2p_listener *l) {
+	fdevent_register(srv->ev, l->conn->fd, network_server_handle_fdevent, srv_socket);
+	fdevent_event_set(srv->ev, &(l->fde_ndx), l->conn->fd, FDEVENT_IN);
+}
+#endif
+
 int network_register_fdevents(server *srv) {
 	size_t i;
 
@@ -1190,6 +1197,15 @@ int network_register_fdevents(server *srv) {
 
 		fdevent_register(srv->ev, srv_socket->fd, network_server_handle_fdevent, srv_socket);
 		fdevent_event_set(srv->ev, &(srv_socket->fde_ndx), srv_socket->fd, FDEVENT_IN);
+
+#ifdef HAVE_I2P
+		if (srv_socket->is_i2p) {
+			i2p_listener *l = srv_socket->i2p_listeners;
+			for (; l != NULL; l = l->next) {
+				network_register_i2p_fdevent(srv, srv_socket, l);
+			}
+		}
+#endif
 	}
 	return 0;
 }

--- a/src/network.h
+++ b/src/network.h
@@ -11,6 +11,9 @@ int network_write_chunkqueue(server *srv, connection *con, chunkqueue *c, off_t 
 int network_init(server *srv);
 int network_close(server *srv);
 
+#ifdef HAVE_I2P
+int network_register_i2p_fdevent(server *srv, server_socket *srv_socket, i2p_listener *l);
+#endif
 int network_register_fdevents(server *srv);
 
 #endif

--- a/src/network_backends.h
+++ b/src/network_backends.h
@@ -59,6 +59,13 @@
 
 #include "base.h"
 
+#if defined(HAVE_I2P)
+int bind_i2p(server *srv, specific_config *s, server_socket *srv_socket,
+		const char *i2p_keyname, unsigned int port);
+int listen_i2p(server_socket *srv_socket, int backlog);
+int accept_i2p(server_socket *srv_socket, struct sockaddr *addr, socklen_t *addrlen);
+#endif
+
 /* return values:
  * >= 0 : no error
  *   -1 : error (on our side)

--- a/src/network_backends.h
+++ b/src/network_backends.h
@@ -63,7 +63,7 @@
 int bind_i2p(server *srv, specific_config *s, server_socket *srv_socket,
 		const char *i2p_keyname, unsigned int port);
 int listen_i2p(server_socket *srv_socket, int backlog);
-int accept_i2p(server_socket *srv_socket, struct sockaddr *addr, socklen_t *addrlen);
+int accept_i2p(server *srv, server_socket *srv_socket, struct sockaddr *addr, socklen_t *addrlen);
 #endif
 
 /* return values:

--- a/src/network_i2p.c
+++ b/src/network_i2p.c
@@ -1,0 +1,288 @@
+#include "first.h"
+
+#include "network_backends.h"
+
+#if defined(HAVE_I2P)
+
+#include "libsam3.h"
+#include "log.h"
+
+#include <errno.h>
+#include <sys/ioctl.h>
+
+static inline void strcpyseserr (Sam3Session *ses, const char *errstr) {
+	memset(ses->error, 0, sizeof(ses->error));
+	if (errstr != NULL) strncpy(ses->error, errstr, sizeof(ses->error)-1);
+}
+
+static inline void strcpyconnerr (Sam3Connection *conn, const char *errstr) {
+	memset(conn->error, 0, sizeof(conn->error));
+	if (errstr != NULL) strncpy(conn->error, errstr, sizeof(conn->error)-1);
+}
+
+Sam3Connection *get_listener(Sam3Session *ses) {
+	SAMFieldList *rep = NULL;
+	Sam3Connection *conn;
+
+	if (ses->type != SAM3_SESSION_STREAM) {
+		strcpyseserr(ses, "INVALID_SESSION_TYPE");
+		errno = EBADF;
+		return NULL;
+	}
+	if (ses->fd < 0) {
+		strcpyseserr(ses, "INVALID_SESSION");
+		errno = EBADF;
+		return NULL;
+	}
+	if ((conn = calloc(1, sizeof(Sam3Connection))) == NULL) {
+		strcpyseserr(ses, "NO_MEMORY");
+		errno = ENOMEM;
+		return NULL;
+	}
+	if ((conn->fd = sam3HandshakeIP(ses->ip, ses->port)) < 0) {
+		strcpyseserr(ses, "IO_ERROR_SK");
+		errno = EADDRNOTAVAIL;
+		goto error;
+	}
+	if (sam3tcpPrintf(conn->fd, "STREAM ACCEPT ID=%s\n", ses->channel) < 0) {
+		strcpyseserr(ses, "IO_ERROR_PF");
+		errno = EADDRNOTAVAIL;
+		goto error;
+	}
+	if ((rep = sam3ReadReply(conn->fd)) == NULL) {
+		strcpyseserr(ses, "IO_ERROR_RP");
+		errno = EADDRNOTAVAIL;
+		goto error;
+	}
+	if (!sam3IsGoodReply(rep, "STREAM", "STATUS", "RESULT", "OK")) {
+		const char *v = sam3FindField(rep, "RESULT");
+		strcpyseserr(ses, (v != NULL && v[0] ? v : "I2P_ERROR_RES"));
+		errno = EADDRNOTAVAIL;
+		goto error;
+	}
+	sam3FreeFieldList(rep);
+	conn->ses = ses;
+	conn->next = ses->connlist;
+	ses->connlist = conn;
+	strcpyseserr(ses, NULL);
+	return conn;
+
+error:
+	if (rep != NULL) sam3FreeFieldList(rep);
+	if (conn->fd >= 0) sam3tcpDisconnect(conn->fd);
+	free(conn);
+	return NULL;
+}
+
+int check_listener(Sam3Connection *conn) {
+	SAMFieldList *rep = NULL;
+	char repstr[1024];
+	int count;
+
+	ioctl(conn->fd, FIONREAD, &count);
+	if (count == 0) {
+		errno = EWOULDBLOCK;
+		return -1;
+	}
+
+	if (sam3tcpReceiveStr(conn->fd, repstr, sizeof(repstr)) < 0) {
+		strcpyconnerr(conn, "IO_ERROR_RP1");
+		errno = ECONNABORTED;
+		goto error;
+	}
+	if ((rep = sam3ParseReply(repstr)) != NULL) {
+		const char *v = sam3FindField(rep, "RESULT");
+		strcpyconnerr(conn, (v != NULL && v[0] ? v : "I2P_ERROR_RES1"));
+		errno = EPROTO;
+		goto error;
+	}
+	if (strlen(repstr) != SAM3_PUBKEY_SIZE) {
+		strcpyconnerr(conn, "INVALID_KEY");
+		errno = EPROTO;
+		goto error;
+	}
+	sam3FreeFieldList(rep);
+	strcpy(conn->destkey, repstr);
+	return 0;
+
+error:
+	if (rep != NULL) sam3FreeFieldList(rep);
+	sam3CloseConnection(conn);
+	return -1;
+}
+
+int bind_i2p(server *srv, specific_config *s, server_socket *srv_socket,
+		const char *i2p_keyname, unsigned int port) {
+	buffer *ob;
+	buffer *kpb;
+	buffer *kb;
+	FILE *fl;
+	char i2p_keybuffer[SAM3_PRIVKEY_SIZE+1];
+
+	/* Prepare SAM options */
+	ob = buffer_init();
+	if (!buffer_is_empty(s->i2p_sam_nickname)) {
+		buffer_copy_string_len(ob, CONST_STR_LEN("inbound.nickname=\""));
+		buffer_append_string_buffer(ob, s->i2p_sam_nickname);
+		buffer_append_string_len(ob, CONST_STR_LEN("\""));
+	} else {
+		buffer_copy_string_len(ob, CONST_STR_LEN("inbound.nickname=lighttpd-"));
+		buffer_append_string(ob, i2p_keyname);
+	}
+
+	/* Prepare keyfile prefix */
+	kpb = buffer_init();
+	if (!buffer_is_empty(srv->srvconf.i2p_sam_keydir)) {
+		buffer_copy_buffer(kpb, srv->srvconf.i2p_sam_keydir);
+		buffer_append_string_len(kpb, CONST_STR_LEN("/"));
+	}
+	buffer_append_string(kpb, i2p_keyname);
+
+	/* Read in the Destination */
+	kb = buffer_init();
+	buffer_copy_buffer(kb, kpb);
+	buffer_append_string_len(kb, CONST_STR_LEN(".privkey"));
+	if (!buffer_is_empty(srv->srvconf.i2p_sam_keydir)) {
+		buffer_path_simplify(kb, kb);
+	}
+
+	if ((fl = fopen(kb->ptr, "rt")) != NULL) {
+		fgets(i2p_keybuffer, SAM3_PRIVKEY_SIZE+1, fl);
+		fclose(fl);
+
+		log_error_write(srv, __FILE__, __LINE__, "ss", "Creating SAMv3 session for", i2p_keyname);
+		if (sam3CreateSession(&(srv_socket->i2p_ses), srv->srvconf.i2p_sam_host, srv->srvconf.i2p_sam_port, i2p_keybuffer, SAM3_SESSION_STREAM, ob->ptr) < 0) {
+			log_error_write(srv, __FILE__, __LINE__, "ss", "SAMv3 SESSION CREATE failed:", strerror(errno));
+			return -1;
+		}
+		log_error_write(srv, __FILE__, __LINE__, "s", "Session built");
+	} else {
+		/* No file, so open a transient SAMv3 session and save its key */
+		log_error_write(srv, __FILE__, __LINE__, "sss", "Creating SAMv3 session for", i2p_keyname, "with new Destination");
+		if (sam3CreateSession(&(srv_socket->i2p_ses), srv->srvconf.i2p_sam_host, srv->srvconf.i2p_sam_port, SAM3_DESTINATION_TRANSIENT, SAM3_SESSION_STREAM, ob->ptr) < 0) {
+			log_error_write(srv, __FILE__, __LINE__, "ss", "SAMv3 SESSION CREATE failed:", strerror(errno));
+			return -1;
+		}
+		log_error_write(srv, __FILE__, __LINE__, "s", "Session built");
+
+		if ((fl = fopen(kb->ptr, "wt")) != NULL) {
+			fwrite(srv_socket->i2p_ses.privkey, strlen(srv_socket->i2p_ses.privkey), 1, fl);
+			fclose(fl);
+			log_error_write(srv, __FILE__, __LINE__, "ss", "Private key saved to", kb->ptr);
+		} else {
+			log_error_write(srv, __FILE__, __LINE__, "sss", "WARNING: Could not save private key to", kb->ptr, "; Destination will be lost on shutdown.");
+		}
+	}
+	buffer_free(ob);
+	buffer_free(kb);
+
+	/* Export current Destination as B64 */
+	kb = buffer_init();
+	buffer_copy_buffer(kb, kpb);
+	buffer_append_string_len(kb, CONST_STR_LEN(".b64.txt"));
+	if (!buffer_is_empty(srv->srvconf.i2p_sam_keydir)) {
+		buffer_path_simplify(kb, kb);
+	}
+	if ((fl = fopen(kb->ptr, "wt")) != NULL) {
+		fwrite(srv_socket->i2p_ses.pubkey, strlen(srv_socket->i2p_ses.pubkey), 1, fl);
+		fclose(fl);
+		log_error_write(srv, __FILE__, __LINE__, "ss", "Destination B64 saved to", kb->ptr);
+	} else {
+		log_error_write(srv, __FILE__, __LINE__, "ss", "WARNING: Could not save Destination B64 to", kb->ptr);
+	}
+	buffer_free(kb);
+
+#ifdef USE_OPENSSL
+	/* Calculate B32 */
+	int raw_dest_len;
+	unsigned char *raw_dest = i2p_unbase64(srv_socket->i2p_ses.pubkey, strlen(srv_socket->i2p_ses.pubkey), &raw_dest_len);
+	unsigned char *hash = SHA256(raw_dest, raw_dest_len, 0);
+	free(raw_dest);
+	char b32_hash[56];
+	sam3Base32Encode(b32_hash, hash, strlen(hash));
+	char *eq_pos = strchrnul(b32_hash, '=');
+	eq_pos[0] = '\0';
+	buffer *b32;
+	b32 = buffer_init();
+	buffer_copy_string(b32, b32_hash);
+	buffer_append_string_len(b32, CONST_STR_LEN(".b32.i2p"));
+
+	/* Export B32 */
+	kb = buffer_init();
+	buffer_copy_string_buffer(kb, kpb);
+	buffer_append_string_len(kb, CONST_STR_LEN(".b32.txt"));
+	if (!buffer_is_empty(srv->srvconf.i2p_sam_keydir)) {
+		buffer_path_simplify(kb, kb);
+	}
+	if ((fl = fopen(kb->ptr, "wt")) != NULL) {
+		fwrite(b32->ptr, strlen(b32->ptr), 1, fl);
+		fclose(fl);
+		log_error_write(srv, __FILE__, __LINE__, "ss", "Destination B32 saved to", kb->ptr);
+	} else {
+		log_error_write(srv, __FILE__, __LINE__, "ss", "WARNING: Could not save Destination B32 to", kb->ptr);
+	}
+	buffer_free(kb);
+#endif
+
+	buffer_free(kpb);
+
+	return 0;
+}
+
+int add_listener(server_socket *srv_socket) {
+	i2p_listener *l;
+	if ((l = calloc(1, sizeof(i2p_listener))) == NULL) {
+		strcpyseserr(&(srv_socket->i2p_ses), "NO_MEMORY");
+		errno = ENOMEM;
+		return -1;
+	}
+	l->conn = get_listener(&(srv_socket->i2p_ses));
+	if (l->conn == NULL) {
+		free(l);
+		return -1;
+	}
+	l->next = srv_socket->i2p_listeners;
+	srv_socket->i2p_listeners = l;
+	return 0;
+}
+
+int listen_i2p(server_socket *srv_socket, int backlog) {
+	// libsam3 currently only supports SAM v3.0; multi-accept was added in v3.2
+	int v32 = 0;
+	for (int i = 0; i < (v32 ? backlog : 1); i++) {
+		if (0 != add_listener(srv_socket)) {
+			return -1;
+		}
+	}
+	return 0;
+}
+
+int accept_i2p(server_socket *srv_socket, struct sockaddr *addr, socklen_t *addrlen) {
+	i2p_listener *l = srv_socket->i2p_listeners;
+	i2p_listener *prev = NULL;
+	while (l != NULL) {
+		if (check_listener(l->conn)) {
+			if (prev == NULL) {
+				srv_socket->i2p_listeners = l->next;
+			} else {
+				prev->next = l->next;
+			}
+
+			int fd = l->conn->fd;
+			free(l);
+
+			// TODO Should this error-out (dropping the new conn), or log?
+			if (0 != add_listener(srv_socket)) {
+				return -1;
+			}
+
+			return fd;
+		} else if (errno != EWOULDBLOCK) {
+			return -1;
+		}
+		prev = l;
+		l = l->next;
+	}
+	return -1;
+}
+#endif /* HAVE_I2P */

--- a/src/request.c
+++ b/src/request.c
@@ -709,6 +709,44 @@ int http_request_parse(server *srv, connection *con) {
 		con->request.http_host = ds->value;
 	}
 
+#ifdef HAVE_I2P
+	if (!buffer_is_empty(con->i2p_dest)) {
+		data_string *ds;
+
+		if (NULL == (ds = (data_string *)array_get_unused_element(con->request.headers, TYPE_STRING))) {
+			ds = data_string_init();
+		}
+
+		buffer_copy_string_len(ds->key, CONST_STR_LEN("X-I2P-DestB64"));
+		buffer_copy_buffer(ds->value, con->i2p_dest);
+		array_insert_unique(con->request.headers, (data_unset *)ds);
+	}
+
+	if (!buffer_is_empty(con->i2p_dest_hash)) {
+		data_string *ds;
+
+		if (NULL == (ds = (data_string *)array_get_unused_element(con->request.headers, TYPE_STRING))) {
+			ds = data_string_init();
+		}
+
+		buffer_copy_string_len(ds->key, CONST_STR_LEN("X-I2P-DestHash"));
+		buffer_copy_buffer(ds->value, con->i2p_dest_hash);
+		array_insert_unique(con->request.headers, (data_unset *)ds);
+	}
+
+	if (!buffer_is_empty(con->i2p_dest_b32)) {
+		data_string *ds;
+
+		if (NULL == (ds = (data_string *)array_get_unused_element(con->request.headers, TYPE_STRING))) {
+			ds = data_string_init();
+		}
+
+		buffer_copy_string_len(ds->key, CONST_STR_LEN("X-I2P-DestB32"));
+		buffer_copy_buffer(ds->value, con->i2p_dest_b32);
+		array_insert_unique(con->request.headers, (data_unset *)ds);
+	}
+#endif
+
 	for (; i <= ilen && !done; i++) {
 		char *cur = con->parse_request->ptr + i;
 

--- a/src/server.c
+++ b/src/server.c
@@ -231,6 +231,10 @@ static server *server_init(void) {
 	CLEAN(srvconf.event_handler);
 	CLEAN(srvconf.pid_file);
 
+#ifdef HAVE_I2P
+	CLEAN(srvconf.i2p_sam_host);
+#endif
+
 	CLEAN(tmp_chunk_len);
 #undef CLEAN
 
@@ -321,6 +325,10 @@ static void server_free(server *srv) {
 	CLEAN(srvconf.modules_dir);
 	CLEAN(srvconf.network_backend);
 	CLEAN(srvconf.xattr_name);
+
+#ifdef HAVE_I2P
+	CLEAN(srvconf.i2p_sam_host);
+#endif
 
 	CLEAN(tmp_chunk_len);
 #undef CLEAN

--- a/src/server.c
+++ b/src/server.c
@@ -233,6 +233,7 @@ static server *server_init(void) {
 
 #ifdef HAVE_I2P
 	CLEAN(srvconf.i2p_sam_host);
+	CLEAN(srvconf.i2p_sam_keydir);
 #endif
 
 	CLEAN(tmp_chunk_len);
@@ -328,6 +329,7 @@ static void server_free(server *srv) {
 
 #ifdef HAVE_I2P
 	CLEAN(srvconf.i2p_sam_host);
+	CLEAN(srvconf.i2p_sam_keydir);
 #endif
 
 	CLEAN(tmp_chunk_len);

--- a/src/server.c
+++ b/src/server.c
@@ -59,6 +59,10 @@
 # include <sys/prctl.h>
 #endif
 
+#ifdef HAVE_I2P
+# include "libsam3.h"
+#endif
+
 #ifdef USE_OPENSSL
 # include <openssl/err.h> 
 #endif
@@ -1743,6 +1747,11 @@ int main (int argc, char **argv) {
 						fdevent_unregister(srv->ev, srv_socket->fd);
 						close(srv_socket->fd);
 						srv_socket->fd = -1;
+#ifdef HAVE_I2P
+						if (srv_socket->is_i2p) {
+							sam3CloseSession(&(srv_socket->i2p_ses));
+						}
+#endif
 
 						/* network_close() will cleanup after us */
 					} else {


### PR DESCRIPTION
This PR adds native I2P support via the [SAM API](https://geti2p.net/en/docs/api/samv3). It considerably simplifies the setup process for a server admin wanting to make their site accessible over I2P.

Still to do:
- Fix integration with `fdevents` subsystem.
- Add default-on enforcement of no `$HTTP["host"]` inside a `$SERVER["socket"] == "i2p:*"` to help prevent [hostname hacking](https://mascherari.press/onionscan-report-this-one-weird-trick-can-reveal-information-from-25-of-the-dark-web-2/).

To build:
- Copy `libsam3.c` and `libsam3.h` into `src/`
  - Currently hosted inside I2P
  - Perhaps these should just be included in the PR? (1073 and 254 lines respectively)
- `./configure --enable-i2p`

Example usage:
```
server.bind = "i2p:test_server"
server.port = 8080
server.document-root = "/path/to/pages/"
server.errorlog = "/path/to/error.log"
server.modules = ( "mod_accesslog" )
accesslog.filename = "/path/to/access.log"
accesslog.format  = "%{X-I2P-DestB64}i %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\""
i2p.sam.port = 7656
i2p.sam.keydir = "/path/to/keys"

$SERVER["socket"] == "i2p:second_server:8081" {
       i2p.sam.nickname = "Alternative server"
}
```