### PR TITLE
[core] fix build issue without ipv6 support

### DIFF
--- a/src/http-header-glue.c
+++ b/src/http-header-glue.c
@@ -1382,6 +1382,8 @@ int http_cgi_headers (server *srv, connection *con, http_cgi_opts *opts, http_cg
     char buf[LI_ITOSTRING_LENGTH];
   #ifdef HAVE_IPV6
     char b2[INET6_ADDRSTRLEN + 1];
+  #else
+    char b2[INET_ADDRSTRLEN + 1];
   #endif
     sock_addr *addr;
     sock_addr addrbuf;


### PR DESCRIPTION
This patch fixes the build issue introduced with when code has been
shared in commit a448886485ea89efed2996838be6ac42b4dd81a9.

	http-header-glue.c: In function 'http_cgi_headers':
	http-header-glue.c:1555:39: error: 'b2' undeclared (first use in this function)
	http-header-glue.c:1555:39: note: each undeclared identifier is reported only once for each function it appears in