### PR TITLE
[mod_proxy] forwarded is a string array only

### DIFF
--- a/src/mod_proxy.c
+++ b/src/mod_proxy.c
@@ -264,15 +264,12 @@ SETDEFAULTS_FUNC(mod_proxy_set_defaults) {
 					s->forwarded |= param;
 				} else if (!buffer_is_equal_string(ds->value, CONST_STR_LEN("disable"))) {
 					log_error_write(srv, __FILE__, __LINE__, "sb",
-						        "proxy.forwarded values must be one of: 0, 1, enable, disable; error for key:", du->key);
+						        "proxy.forwarded values must be one of: enable, disable; error for key:", du->key);
 					return HANDLER_ERROR;
 				}
-			} else if (du->type == TYPE_INTEGER) {
-				data_integer *di = (data_integer *)du;
-				if (di->value) s->forwarded |= param;
 			} else {
 				log_error_write(srv, __FILE__, __LINE__, "sb",
-					        "proxy.forwarded values must be one of: 0, 1, enable, disable; error for key:", du->key);
+					        "proxy.forwarded values must be one of: enable, disable; error for key:", du->key);
 				return HANDLER_ERROR;
 			}
 		}


### PR DESCRIPTION
The folllowing proxy configuration cannot be loaded

	proxy.forwarded = (
		"for" => 1
	)

	2017-04-25 13:36:20: (configfile-glue.c.63) the value of an array can only be a string, variable: proxy.forwarded [ for ], type: 4
	2017-04-25 13:36:20: (server.c.1286) Configuration of plugins failed. Going down.

As log reports, arrays can only contains strings values.

This patch removes support for integer values and fixes traces saying
that both 0 and 1 are valid values. The following configuration is also
invalid.

	proxy.forwarded = (
		"for" => 1
	)

	2017-04-25 13:37:20: (mod_proxy.c.266) proxy.forwarded values must be one of: 0, 1, enable, disable; error for key: for