### PR TITLE
[mod_openssl] Allow to selectively disable TLS 1.0, 1.1 and 1.2 versions

### DIFF
--- a/doc/config/lighttpd.conf
+++ b/doc/config/lighttpd.conf
@@ -485,6 +485,17 @@ server.upload-dirs = ( "/var/tmp" )
 #ssl.ca-crl-file = ""
 
 ##
+## it is also possible to selectively enable/disable SSL/TLS versions, by setting the following parameters accordingly.
+## TLS v1.1 and TLS v1.2 are enabled by default.
+##
+##
+#ssl.use-sslv2 = "disable"
+#ssl.use-sslv3 = "disable"
+#ssl.use-tlsv10 = "disable"
+#ssl.use-tlsv11 = "enable"
+#ssl.use-tlsv12 = "enable"
+
+##
 #######################################################################
 
 #######################################################################

--- a/src/mod_openssl.c
+++ b/src/mod_openssl.c
@@ -55,6 +55,9 @@ typedef struct {
     unsigned short ssl_empty_fragments; /* whether to not set SSL_OP_DONT_INSERT_EMPTY_FRAGMENTS */
     unsigned short ssl_use_sslv2;
     unsigned short ssl_use_sslv3;
+    unsigned short ssl_use_tlsv10;
+    unsigned short ssl_use_tlsv11;
+    unsigned short ssl_use_tlsv12;
     buffer *ssl_pemfile;
     buffer *ssl_ca_file;
     buffer *ssl_ca_crl_file;
@@ -690,6 +693,39 @@ network_init_ssl (server *srv, void *p_d)
             }
         }
 
+        if (!s->ssl_use_tlsv10 && 0 != SSL_OP_NO_TLSv1) {
+            /* disable TLSv1.0 */
+            if ((SSL_OP_NO_TLSv1
+                 & SSL_CTX_set_options(s->ssl_ctx, SSL_OP_NO_TLSv1))
+                != SSL_OP_NO_TLSv1) {
+                log_error_write(srv, __FILE__, __LINE__, "ss", "TLS:",
+                                ERR_error_string(ERR_get_error(), NULL));
+                return -1;
+            }
+        }
+
+        if (!s->ssl_use_tlsv11 && 0 != SSL_OP_NO_TLSv1_1) {
+            /* disable TLSv1.1 */
+            if ((SSL_OP_NO_TLSv1_1
+                 & SSL_CTX_set_options(s->ssl_ctx, SSL_OP_NO_TLSv1_1))
+                != SSL_OP_NO_TLSv1_1) {
+                log_error_write(srv, __FILE__, __LINE__, "ss", "TLS:",
+                                ERR_error_string(ERR_get_error(), NULL));
+                return -1;
+            }
+        }
+
+        if (!s->ssl_use_tlsv12 && 0 != SSL_OP_NO_TLSv1_2) {
+            /* disable TLSv1.2 */
+            if ((SSL_OP_NO_TLSv1_2
+                 & SSL_CTX_set_options(s->ssl_ctx, SSL_OP_NO_TLSv1_2))
+                != SSL_OP_NO_TLSv1_2) {
+                log_error_write(srv, __FILE__, __LINE__, "ss", "TLS:",
+                                ERR_error_string(ERR_get_error(), NULL));
+                return -1;
+            }
+        }
+
         if (!buffer_string_is_empty(s->ssl_cipher_list)) {
             /* Disable support for low encryption ciphers */
             if (SSL_CTX_set_cipher_list(s->ssl_ctx,s->ssl_cipher_list->ptr)!=1){
@@ -909,8 +945,11 @@ SETDEFAULTS_FUNC(mod_openssl_set_defaults)
         { "ssl.verifyclient.exportcert",       NULL, T_CONFIG_BOOLEAN, T_CONFIG_SCOPE_CONNECTION }, /* 15 */
         { "ssl.use-sslv2",                     NULL, T_CONFIG_BOOLEAN, T_CONFIG_SCOPE_CONNECTION }, /* 16 */
         { "ssl.use-sslv3",                     NULL, T_CONFIG_BOOLEAN, T_CONFIG_SCOPE_CONNECTION }, /* 17 */
-        { "ssl.ca-crl-file",                   NULL, T_CONFIG_STRING,  T_CONFIG_SCOPE_CONNECTION }, /* 18 */
-        { "ssl.ca-dn-file",                    NULL, T_CONFIG_STRING,  T_CONFIG_SCOPE_CONNECTION }, /* 19 */
+        { "ssl.use-tlsv10",                     NULL, T_CONFIG_BOOLEAN, T_CONFIG_SCOPE_CONNECTION }, /* 18 */
+        { "ssl.use-tlsv11",                     NULL, T_CONFIG_BOOLEAN, T_CONFIG_SCOPE_CONNECTION }, /* 19 */
+        { "ssl.use-tlsv12",                     NULL, T_CONFIG_BOOLEAN, T_CONFIG_SCOPE_CONNECTION }, /* 20 */
+        { "ssl.ca-crl-file",                   NULL, T_CONFIG_STRING,  T_CONFIG_SCOPE_CONNECTION }, /* 21 */
+        { "ssl.ca-dn-file",                    NULL, T_CONFIG_STRING,  T_CONFIG_SCOPE_CONNECTION }, /* 22 */
         { NULL,                         NULL, T_CONFIG_UNSET, T_CONFIG_SCOPE_UNSET }
     };
 
@@ -934,6 +973,9 @@ SETDEFAULTS_FUNC(mod_openssl_set_defaults)
         s->ssl_empty_fragments = 0;
         s->ssl_use_sslv2 = 0;
         s->ssl_use_sslv3 = 0;
+        s->ssl_use_tlsv10 = 0;
+        s->ssl_use_tlsv11 = 1;
+        s->ssl_use_tlsv12 = 1;
         s->ssl_verifyclient = 0;
         s->ssl_verifyclient_enforce = 1;
         s->ssl_verifyclient_username = buffer_init();
@@ -962,8 +1004,11 @@ SETDEFAULTS_FUNC(mod_openssl_set_defaults)
         cv[15].destination = &(s->ssl_verifyclient_export_cert);
         cv[16].destination = &(s->ssl_use_sslv2);
         cv[17].destination = &(s->ssl_use_sslv3);
-        cv[18].destination = s->ssl_ca_crl_file;
-        cv[19].destination = s->ssl_ca_dn_file;
+        cv[18].destination = &(s->ssl_use_tlsv10);
+        cv[19].destination = &(s->ssl_use_tlsv11);
+        cv[20].destination = &(s->ssl_use_tlsv12);
+        cv[21].destination = s->ssl_ca_crl_file;
+        cv[22].destination = s->ssl_ca_dn_file;
 
         p->config_storage[i] = s;
 
@@ -1017,6 +1062,9 @@ mod_openssl_patch_connection (server *srv, connection *con, handler_ctx *hctx)
     /*PATCH(ssl_empty_fragments);*//*(not patched)*/
     /*PATCH(ssl_use_sslv2);*//*(not patched)*/
     /*PATCH(ssl_use_sslv3);*//*(not patched)*/
+    /*PATCH(ssl_use_tlsv10);*//*(not patched)*/
+    /*PATCH(ssl_use_tlsv11);*//*(not patched)*/
+    /*PATCH(ssl_use_tlsv12);*//*(not patched)*/
 
     PATCH(ssl_verifyclient);
     PATCH(ssl_verifyclient_enforce);
@@ -1077,6 +1125,12 @@ mod_openssl_patch_connection (server *srv, connection *con, handler_ctx *hctx)
                 PATCH(ssl_use_sslv2);
             } else if (buffer_is_equal_string(du->key, CONST_STR_LEN("ssl.use-sslv3"))) {
                 PATCH(ssl_use_sslv3);
+            }else if (buffer_is_equal_string(du->key, CONST_STR_LEN("ssl.use-tlsv10"))) {
+                PATCH(ssl_use_tlsv10);
+            }else if (buffer_is_equal_string(du->key, CONST_STR_LEN("ssl.use-tlsv11"))) {
+                PATCH(ssl_use_tlsv11);
+            }else if (buffer_is_equal_string(du->key, CONST_STR_LEN("ssl.use-tlsv12"))) {
+                PATCH(ssl_use_tlsv12);
             } else if (buffer_is_equal_string(du->key, CONST_STR_LEN("ssl.cipher-list"))) {
                 PATCH(ssl_cipher_list);
             } else if (buffer_is_equal_string(du->key, CONST_STR_LEN("ssl.dh-file"))) {


### PR DESCRIPTION
Up until now, lighttpd allowed to disable SSLv2 and SSLv3 through the ssl.use-sslv2 and ssl.use-sslv2 lighttpd.conf options, however the same was not offered to selectively disable TLS versions.

On the lighttpd forum, only enabling the TLS 1.2 ciphers is suggested as a mitigation to disable TLS 1.0 (https://redmine.lighttpd.net/boards/2/topics/5797), however it disables TLS 1.1 as well.

This patch adds the option to selectively disable the TLS versions (using OpenSSL's SSL_OP_NO_TLSv1, SSL_OP_NO_TLSv1_1, SSL_OP_NO_TLSv1_2 parameters), without having to change the cipher suite configuration, by adding the ssl.use-tlsv10, ssl.use-tlsv11 and ssl.use-tlsv12 lighttpd.conf options.