### PR TITLE
fix crash in mod_webdav_subrequest_handler_huge()

### DIFF
--- a/src/mod_webdav.c
+++ b/src/mod_webdav.c
@@ -1339,6 +1339,14 @@ SUBREQUEST_FUNC(mod_webdav_subrequest_handler_huge) {
 				con->http_status = 404;
 				return HANDLER_FINISHED;
 			}
+			else if (errno == EACCES) {
+				con->http_status = 403;
+				return HANDLER_FINISHED;
+			}
+			else {
+				con->http_status = 500;
+				return HANDLER_FINISHED;
+			}
 			break;
 		default:
 			break;


### PR DESCRIPTION
Using `lighttpd-1.4.45-1.el7.x86_64` on `CentOS 7.4` with webdav module configured, I had a crash of lighttpd for segmentation fault inside `mod_webdav_subrequest_handler_huge() `function.

After installing debuginfo package and analyzing the coredump with `gdb` (see below), I found that the problem happens under the following sequence of events:
 1) under document-root there is a file for which lighttpd (running as unprivileged user) has no read permissions (`/var/log/boot.log` in my case)
 2) the external client tries to access mentioned file via webdav
 3) lighttpd crashes because of segmentation fault inside `mod_webdav.c:1355`. In particular pointer `sce` is NULL.

The problem happens because of how error condition from call of `stat_cache_get_entry() ` is managed: if `HANDLER_ERROR` is returned but errno is not equal to `ENOENT `(in my case errno was in fact `EACCES`), the function continues execution and tries to access `sce` pointer, which is NULL since `stat_cache_get_entry()` returned error.

Attached is the patch I applied to solve the crash.
Please include a similar protection in one of the next releases. Even if under document-root there are normally only readable files, it's not nice to crash if there is one not readable.

```
[root@dev-local tmp]# gdb /usr/sbin/lighttpd /tmp/core-lighttpd-sig11-user995-group992-pid3938-time1508770384
GNU gdb (GDB) Red Hat Enterprise Linux 7.6.1-100.el7
Copyright (C) 2013 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.  Type "show copying"
and "show warranty" for details.
This GDB was configured as "x86_64-redhat-linux-gnu".
For bug reporting instructions, please see:
<http://www.gnu.org/software/gdb/bugs/>...
Reading symbols from /usr/sbin/lighttpd...Reading symbols from /usr/lib/debug/usr/sbin/lighttpd.debug...done.
done.
[New LWP 3938]
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/lib64/libthread_db.so.1".
Core was generated by `/usr/sbin/lighttpd -D -f /etc/lighttpd/lighttpd.conf'.
Program terminated with signal 11, Segmentation fault.
#0  0x00007fa807542fd6 in mod_webdav_subrequest_handler_huge (srv=0x55cbf8dd4030, con=con@entry=0x55cbf8de62c0, p_d=0x55cbf8dddc30) at mod_webdav.c:1355
1355                    if (S_ISDIR(sce->st.st_mode) && con->physical.path->ptr[buffer_string_length(con->physical.path)-1] != '/') {
Missing separate debuginfos, use: debuginfo-install gamin-0.1.10-16.el7.x86_64 glibc-2.17-196.el7.x86_64 keyutils-libs-1.5.8-3.el7.x86_64 krb5-libs-1.15.1-8.el7.x86_64 libcom_err-1.42.9-10.el7.x86_64 libselinux-2.5-11.el7.x86_64 openssl-libs-1.0.2k-8.el7.x86_64 pcre-8.32-17.el7.x86_64 sssd-client-1.15.2-50.el7_4.2.x86_64 zlib-1.2.7-17.el7.x86_64
(gdb) bt
#0  0x00007fa807542fd6 in mod_webdav_subrequest_handler_huge (srv=0x55cbf8dd4030, con=con@entry=0x55cbf8de62c0, p_d=0x55cbf8dddc30) at mod_webdav.c:1355
#1  0x00007fa8075448b5 in mod_webdav_subrequest_handler (srv=<optimized out>, con=0x55cbf8de62c0, p_d=<optimized out>) at mod_webdav.c:2719
#2  0x000055cbf7562937 in plugins_call_handle_subrequest (srv=srv@entry=0x55cbf8dd4030, con=con@entry=0x55cbf8de62c0) at plugin.c:334
#3  0x000055cbf754cb0d in http_response_prepare (srv=srv@entry=0x55cbf8dd4030, con=con@entry=0x55cbf8de62c0) at response.c:788
#4  0x000055cbf754f4ab in connection_state_machine (srv=srv@entry=0x55cbf8dd4030, con=con@entry=0x55cbf8de62c0) at connections.c:1158
#5  0x000055cbf754aa66 in main (argc=<optimized out>, argv=<optimized out>) at server.c:1812
(gdb) p sce
$1 = (stat_cache_entry *) 0x0
(gdb) p errno
$2 = 13
(gdb) p con->physical.path->ptr
$3 = 0x55cbf8e30740 "/var/log/boot.log"
(gdb) quit
[root@dev-local tmp]#
```