### PR TITLE
Fixed build error when option --disable-ipv6 is used (issue #2832)

### DIFF
--- a/src/network.c
+++ b/src/network.c
@@ -77,9 +77,13 @@ static void network_host_normalize_addr_str(buffer *host, sock_addr *addr) {
     if (addr->plain.sa_family == AF_INET6)
         buffer_append_string_len(host, CONST_STR_LEN("]"));
     if (addr->plain.sa_family != AF_UNIX) {
+#ifdef HAVE_IPV6
         unsigned short port = (addr->plain.sa_family == AF_INET)
           ? ntohs(addr->ipv4.sin_port)
           : ntohs(addr->ipv6.sin6_port);
+#else
+        unsigned short port = ntohs(addr->ipv4.sin_port);
+#endif
         buffer_append_string_len(host, CONST_STR_LEN(":"));
         buffer_append_int(host, (int)port);
     }


### PR DESCRIPTION
This patch fixes bug #2832 (on redmine).
https://redmine.lighttpd.net/issues/2832