### PR TITLE
Disable RC4 explicitly as per RFC7465

### DIFF
--- a/doc/config/lighttpd.conf
+++ b/doc/config/lighttpd.conf
@@ -442,6 +442,8 @@ server.upload-dirs = ( "/var/tmp" )
 ##     # https://www.ssllabs.com/projects/best-practices/index.html)
 ##     # - BEAST is considered mitigaed on client side now, and new weaknesses have been found in RC4,
 ##     #   so it is strongly advised to disable RC4 ciphers (HIGH doesn't include RC4)
+##     #   As per RFC7465 (published in February 2015), the IETF explicitly prohibits RC4.
+##     #   https://tools.ietf.org/html/rfc7465
 ##     # - It is recommended to disable 3DES too (although disabling RC4 and 3DES breaks IE6+8 on Windows XP,
 ##     #   so you might want to support 3DES for now - just remove the '!3DES' parts below).
 ##     # - The examples below prefer ciphersuites with "Forward Secrecy" (and ECDHE over DHE (alias EDH)), remove '+kEDH +kRSA'
@@ -450,9 +452,9 @@ server.upload-dirs = ( "/var/tmp" )
 ##     # Check your cipher list with: openssl ciphers -v '...' (use single quotes as your shell won't like ! in double quotes)
 ##     #
 ##     # If you know you have RSA keys (standard), you can use:
-##     ssl.cipher-list             = "aRSA+HIGH !3DES +kEDH +kRSA !kSRP !kPSK"
+##     ssl.cipher-list             = "aRSA+HIGH !3DES !RC4 +kEDH +kRSA !kSRP !kPSK"
 ##     # The more generic version (without the restriction to RSA keys) is
-##     # ssl.cipher-list           = "HIGH !aNULL !3DES +kEDH +kRSA !kSRP !kPSK"
+##     # ssl.cipher-list           = "HIGH !aNULL !3DES !RC4 +kEDH +kRSA !kSRP !kPSK"
 ##     #
 ##     # Make the server prefer the order of the server side cipher suite instead of the client suite.
 ##     # This option is enabled by default, but only used if ssl.cipher-list is set.


### PR DESCRIPTION
As per RFC7465, added RC4 to the default disabled weak ciphers.
https://tools.ietf.org/html/rfc7465