### PR TITLE
[mod_accesslog] IP address privacy

### DIFF
--- a/doc/config/conf.d/access_log.conf
+++ b/doc/config/conf.d/access_log.conf
@@ -23,5 +23,24 @@ accesslog.filename          = log_root + "/access.log"
 ##
 #accesslog.use-syslog       = "enable"
 
+
+##
+## Specify whether and how often the request origin IP address should be
+## randomized in the log file
+##
+## If enabled, the IP address as a text string is concatenated with a
+## 128-bit random salt and SHA256-hashed, with 64 bits of the resulting hash
+## put into the log file instead of the clear text IP.
+##
+## Please specify the re-salting interval here. The salt is not
+## stored anywhere but in lighttpd's process RAM.
+## The interval is specified in seconds. A value of zero (the default)
+## disables this functionality.
+##
+## This functionality is meant to respect a visitor's privacy while
+## still allowing for decent log file analysis.
 #
+# accesslog.ip-randomize-interval = 86400
+
+
 #######################################################################


### PR DESCRIPTION
To respect a user's privacy and make him or her pseudonymous, extra
functionality is hereby added to mod_accesslog.

When enabled using the "accesslog.ip-randomize-interval" configuration
variable, it will randomize a user's IP by concatenating it with a
regularly changing random number
(the randomize interval), hash it (using SHA256), and print 64 bits of
the resulting hash into the log file as a hex string.

This should allow for log file and click stream analysis (continuity of
the resulting hash fingerprint) while respecting the privacy of visitors.

This functionality is only enabled when openssl support is compiled into
lighttpd.