### PR TITLE
[core] use kill_signal for gw_proc_kill

### DIFF
--- a/src/gw_backend.c
+++ b/src/gw_backend.c
@@ -701,7 +701,7 @@ static void gw_proc_kill(server *srv, gw_host *host, gw_proc *proc) {
         host->unused_procs->prev = proc;
     host->unused_procs = proc;
 
-    kill(proc->pid, SIGTERM);
+    kill(proc->pid, host->kill_signal);
 
     gw_proc_set_state(host, proc, PROC_STATE_KILLED);
 


### PR DESCRIPTION
`kill-signal`, added in 1.4.15, isn't used with `idle-timeout` (which seems was originally added only for mod_scgi, and presently still uses SIGTERM via `gw_proc_kill`), therefore fastcgi processes couldn't be killed with `idle-timeout`.