### PR TITLE
[core] Fix recursive include_shell invocations

### DIFF
--- a/src/configfile.c
+++ b/src/configfile.c
@@ -1437,8 +1437,7 @@ int config_parse_cmd(server *srv, config_t *context, const char *cmd) {
 			ssize_t rd;
 			pid_t wpid;
 			int wstatus;
-			buffer *out = srv->tmp_buf;
-			buffer_clear(out);
+			buffer *out = buffer_init();
 			close(fds[1]);
 			fds[1] = -1;
 			do {
@@ -1471,6 +1470,7 @@ int config_parse_cmd(server *srv, config_t *context, const char *cmd) {
 				ret = config_parse(srv, context, &t);
 				buffer_free(source);
 			}
+			buffer_free(out);
 		}
 		if (-1 != fds[0]) close(fds[0]);
 		if (-1 != fds[1]) close(fds[1]);


### PR DESCRIPTION
When the output of include_shell calls include_shell itself,
that second invocation must not truncate the buffer used for the
outer include_shell.

This might sound like a pathological setup in itself, but with
e.g.  debian's include-conf-enabled.pl, which outputs a list of
include statements for all files in /etc/lighttpd/conf-enabled,
if any of the *.conf files in that directory invokes include_shell,
the parsing of the rest of the files in that directory is effectively
aborted.

This fixes a regression in such setups since commit
a46bc4f5de49c742e4bdc6ac7be6a4e567c8d92a.