### PR TITLE
doc/systemd: add example lighttpd.socket for systemd socket activation

### DIFF
--- a/doc/config/lighttpd.conf
+++ b/doc/config/lighttpd.conf
@@ -104,6 +104,12 @@ server.use-ipv6 = "enable"
 server.username  = "lighttpd"
 server.groupname = "lighttpd"
 
+##
+## Enable lighttpd accepting connections from passed file descriptors.
+## https://www.freedesktop.org/software/systemd/man/systemd.socket.html
+##
+#server.systemd-socket-activation = "enable"
+
 ## 
 ## enable core files.
 ##

--- a/doc/systemd/Makefile.am
+++ b/doc/systemd/Makefile.am
@@ -1,1 +1,1 @@
-EXTRA_DIST=lighttpd.service
+EXTRA_DIST=lighttpd.service lighttpd.socket

--- a/doc/systemd/lighttpd.socket
+++ b/doc/systemd/lighttpd.socket
@@ -1,3 +1,6 @@
+# please note:
+# server.systemd-socket-activation option needs to be enabled in lighttpd config for socket activation to work.
+
 [Unit]
 Description=lighttpd socket
 

--- a/doc/systemd/lighttpd.socket
+++ b/doc/systemd/lighttpd.socket
@@ -1,12 +1,14 @@
-# please note:
-# server.systemd-socket-activation option needs to be enabled in lighttpd config for socket activation to work.
+# please note: lighttpd.conf must contain directive: server.systemd-socket-activation = "enable"
 
 [Unit]
 Description=lighttpd socket
 
 [Socket]
+# Enable listening on http port
 ListenStream=80
-ListenStream=443
+# To enable listening on https port, you need first setup SSL
+# https://redmine.lighttpd.net/projects/lighttpd/wiki/Docs_SSL
+#ListenStream=443
 Service=lighttpd.service
 
 [Install]

--- a/doc/systemd/lighttpd.socket
+++ b/doc/systemd/lighttpd.socket
@@ -1,0 +1,10 @@
+[Unit]
+Description=lighttpd socket
+
+[Socket]
+ListenStream=80
+ListenStream=443
+Service=lighttpd.service
+
+[Install]
+WantedBy=sockets.target


### PR DESCRIPTION
See discussion: https://github.com/lighttpd/lighttpd1.4/commit/ce7b47c015d6ce724ad6361c2df7a4853058654a#commitcomment-32195132

Systemd Docs:
- https://www.freedesktop.org/software/systemd/man/systemd.socket.html

However, not sure how to indicate that `server.systemd-socket-activation` needs to be enabled in config.