### PR TITLE
Fix compile error when system has SOCK_CLOEXEC but not SOCK_NONBLOCK

### DIFF
--- a/src/fdevent.c
+++ b/src/fdevent.c
@@ -165,10 +165,16 @@ fdevents *fdevent_init(server *srv) {
 	 * (reported on Android running a custom ROM)
 	 * https://redmine.lighttpd.net/issues/2883
 	 */
+	#ifdef SOCK_NONBLOCK
 	int fd = socket(AF_INET, SOCK_STREAM | SOCK_CLOEXEC | SOCK_NONBLOCK, 0);
+	#else
+	int fd = socket(AF_INET, SOCK_STREAM | SOCK_CLOEXEC, 0);
+	#endif
 	if (fd >= 0) {
+		#ifdef SOCK_NONBLOCK
 		int flags = fcntl(fd, F_GETFL, 0);
 		use_sock_nonblock = (-1 != flags && (flags & O_NONBLOCK));
+		#endif
 		use_sock_cloexec = 1;
 		close(fd);
 	}
@@ -497,9 +503,19 @@ int fdevent_socket_cloexec(int domain, int type, int protocol) {
 int fdevent_socket_nb_cloexec(int domain, int type, int protocol) {
 	int fd;
 #ifdef SOCK_CLOEXEC
+#ifdef SOCK_NONBLOCK
 	if (use_sock_cloexec && use_sock_nonblock)
 		return socket(domain, type | SOCK_CLOEXEC | SOCK_NONBLOCK, protocol);
+#else
+	if (use_sock_cloexec && -1 != (fd = socket(domain, type | SOCK_CLOEXEC, protocol))) {
+#ifdef O_NONBLOCK
+		force_assert(-1 != fcntl(fd, F_SETFL, O_NONBLOCK | O_RDWR));
 #endif
+		return fd;
+       }
+#endif
+#endif
+
 	if (-1 != (fd = socket(domain, type, protocol))) {
 #ifdef FD_CLOEXEC
 		force_assert(-1 != fcntl(fd, F_SETFD, FD_CLOEXEC));


### PR DESCRIPTION
My system has SOCK_CLOEXEC but not SOCK_NONBLOCK. This cause the build to break.
This commit should fix this.