### PR TITLE
[systemd]: update /var/run -> /run for systemd

### DIFF
--- a/doc/systemd/lighttpd.service
+++ b/doc/systemd/lighttpd.service
@@ -4,7 +4,7 @@ After=network-online.target
 
 [Service]
 Type=simple
-PIDFile=/var/run/lighttpd.pid
+PIDFile=/run/lighttpd.pid
 ExecStartPre=/usr/sbin/lighttpd -tt -f /etc/lighttpd/lighttpd.conf
 ExecStart=/usr/sbin/lighttpd -D -f /etc/lighttpd/lighttpd.conf
 ExecReload=/bin/kill -USR1 $MAINPID


### PR DESCRIPTION
This gets rid of the warning:
> May 19 10:56:32 buster systemd[1]: /lib/systemd/system/lighttpd.service:6: PIDFile= references path below legacy directory /var/run/, updating /var/run/lighttpd.pid → /run/lighttpd.pid; please update the unit file accordingly.

refs:
- https://github.com/systemd/systemd/commit/a2d1fb882c4308bc10362d971f333c5031d60069
- https://github.com/systemd/systemd/pull/9019
- https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=929203