### PR TITLE
malloc without free

### DIFF
--- a/src/lemon.c
+++ b/src/lemon.c
@@ -3869,6 +3869,7 @@ char *data;
     free(x1a->tbl);
     /* *x1a = array; *//* copy 'array' */
     memcpy(x1a, &array, sizeof(array));
+    free(array.tbl);	  
   }
   /* Insert the new data */
   h = ph & (x1a->size-1);
@@ -4034,6 +4035,7 @@ char *key;
     free(x2a->tbl);
     /* *x2a = array; *//* copy 'array' */
     memcpy(x2a, &array, sizeof(array));
+    free(array.tbl);		  
   }
   /* Insert the new data */
   h = ph & (x2a->size-1);
@@ -4241,6 +4243,7 @@ struct config *key;
     free(x3a->tbl);
     /* *x3a = array; *//* copy 'array' */
     memcpy(x3a, &array, sizeof(array));
+    free(array.tbl);		  
   }
   /* Insert the new data */
   h = ph & (x3a->size-1);
@@ -4392,6 +4395,7 @@ struct config *data;
     free(x4a->tbl);
     /* *x4a = array; *//* copy 'array' */
     memcpy(x4a, &array, sizeof(array));
+    free(array.tbl);		  
   }
   /* Insert the new data */
   h = ph & (x4a->size-1);


### PR DESCRIPTION
Hi everyone,

I found an opportunity for improvement this code. I believe in this case we need to call the free() function. In this case, we have 2 types of weaknesses: CWE 399 (Resource Management Errors) and CWE 772 (Missing Release of Resource after Effective Lifetime).

According to CWE 772: "When a resource is not released after use, it can allow attackers to cause a denial of service by causing the allocation of resources without triggering their release. Frequently-affected resources include memory, CPU, disk space, power or battery, etc."

CWE 339: https://cwe.mitre.org/data/definitions/399.html
CWE 772: https://cwe.mitre.org/data/definitions/772.html

Regards