### PR TITLE
Fix kill children and shutdown by signal

### DIFF
--- a/src/fdevent.c
+++ b/src/fdevent.c
@@ -815,6 +815,10 @@ int fdevent_waitpid(pid_t pid, int * const status, int nb) {
     return rv;
 }
 
+int fdevent_waitpid_intr(pid_t pid, int * const status) {
+    return waitpid(pid, status, 0);
+}
+
 
 typedef struct fdevent_cmd_pipe {
     pid_t pid;

--- a/src/fdevent.h
+++ b/src/fdevent.h
@@ -100,6 +100,7 @@ int fdevent_open_dirname(char *path, int symlinks);
 int fdevent_set_stdin_stdout_stderr(int fdin, int fdout, int fderr);
 pid_t fdevent_fork_execve(const char *name, char *argv[], char *envp[], int fdin, int fdout, int fderr, int dfd);
 int fdevent_waitpid(pid_t pid, int *status, int nb);
+int fdevent_waitpid_intr(pid_t pid, int *status);
 int fdevent_open_logger(const char *logger);
 int fdevent_cycle_logger(const char *logger, int *curfd);
 int fdevent_reaped_logger_pipe(pid_t pid);

--- a/src/server.c
+++ b/src/server.c
@@ -1610,7 +1610,7 @@ static int server_main_setup (server * const srv, int argc, char **argv) {
 			} else {
 				int status;
 
-				if (-1 != (pid = fdevent_waitpid(-1, &status, 0))) {
+				if (-1 != (pid = fdevent_waitpid_intr(-1, &status))) {
 					log_monotonic_secs = server_monotonic_secs();
 					log_epoch_secs = server_epoch_secs(srv);
 					if (plugins_call_handle_waitpid(srv, pid, status) != HANDLER_GO_ON) {


### PR DESCRIPTION
Graceful shutdown by signal to master process was broken in 29f50bde.
We should not quiet ignore EINTR in the main loop.