### PR TITLE
Make tests pass after 2035

### DIFF
--- a/tests/request.t
+++ b/tests/request.t
@@ -460,10 +460,12 @@ EOF
 $t->{RESPONSE} = [ { 'HTTP-Protocol' => 'HTTP/1.0', 'HTTP-Status' => 400 } ];
 ok($tf->handle_http($t) == 0, 'OPTIONS for RTSP');
 
+my $nextyr = (gmtime(time()))[5] + 1900 + 1;
+
 $t->{REQUEST}  = ( <<EOF
 GET /index.html HTTP/1.0
-If-Modified-Since: Sun, 01 Jan 2036 00:00:02 GMT
-If-Modified-Since: Sun, 01 Jan 2036 00:00:02 GMT
+If-Modified-Since: Sun, 01 Jan $nextyr 00:00:02 GMT
+If-Modified-Since: Sun, 01 Jan $nextyr 00:00:02 GMT
 EOF
  );
 $t->{RESPONSE} = [ { 'HTTP-Protocol' => 'HTTP/1.0', 'HTTP-Status' => 304 } ];
@@ -484,8 +486,8 @@ ok($tf->handle_http($t) == 0, 'broken If-Modified-Since');
 
 $t->{REQUEST}  = ( <<EOF
 GET /index.html HTTP/1.0
-If-Modified-Since2: Sun, 01 Jan 2036 00:00:03 GMT
-If-Modified-Since: Sun, 01 Jan 2036 00:00:02 GMT
+If-Modified-Since2: Sun, 01 Jan $nextyr 00:00:03 GMT
+If-Modified-Since: Sun, 01 Jan $nextyr 00:00:02 GMT
 EOF
  );
 $t->{RESPONSE} = [ { 'HTTP-Protocol' => 'HTTP/1.0', 'HTTP-Status' => 304 } ];
@@ -493,7 +495,7 @@ ok($tf->handle_http($t) == 0, 'Similar Headers (bug #1287)');
 
 $t->{REQUEST}  = ( <<EOF
 GET /index.html HTTP/1.0
-If-Modified-Since: Sun, 01 Jan 2036 00:00:02 GMT
+If-Modified-Since: Sun, 01 Jan $nextyr 00:00:02 GMT
 EOF
  );
 $t->{RESPONSE} = [ { 'HTTP-Protocol' => 'HTTP/1.0', 'HTTP-Status' => 304, 'Content-Type' => 'text/html' } ];
@@ -501,7 +503,7 @@ ok($tf->handle_http($t) == 0, 'If-Modified-Since');
 
 $t->{REQUEST}  = ( <<EOF
 GET /index.html HTTP/1.0
-If-Modified-Since: Sun, 01 Jan 2036 00:00:02 GMT
+If-Modified-Since: Sun, 01 Jan $nextyr 00:00:02 GMT
 EOF
  );
 $t->{RESPONSE} = [ { 'HTTP-Protocol' => 'HTTP/1.0', 'HTTP-Status' => 304, '-Content-Length' => '' } ];


### PR DESCRIPTION
I could not test if it still passes on i586, but if the test fails there, you want to see that anyway.

Background:
As part of my work on reproducible builds for openSUSE, I check that software still gives identical build results in the future.
The usual offset is +15 years, because that is how long I expect some software will be used in some places.
This showed up failing tests in our package build.
See https://reproducible-builds.org/ for why this matters.