### PR TITLE
[core] forward connection reset from backend to client

### DIFF
--- a/src/base.h
+++ b/src/base.h
@@ -120,6 +120,7 @@ typedef struct {
 	unsigned char config_unsupported;
 	unsigned char systemd_socket_activation;
 	unsigned char errorlog_use_syslog;
+	unsigned char forward_reset;
 	const buffer *syslog_facility;
 	const buffer *bindhost;
 	const buffer *changeroot;

--- a/src/configfile.c
+++ b/src/configfile.c
@@ -721,6 +721,9 @@ static int config_insert_srvconf(server *srv) {
      ,{ CONST_STR_LEN("server.feature-flags"),
         T_CONFIG_ARRAY_KVANY,
         T_CONFIG_SCOPE_SERVER }
+     ,{ CONST_STR_LEN("server.forward-reset"),
+        T_CONFIG_BOOL,
+        T_CONFIG_SCOPE_SERVER }
      ,{ NULL, 0,
         T_CONFIG_UNSET,
         T_CONFIG_SCOPE_UNSET }
@@ -877,6 +880,9 @@ static int config_insert_srvconf(server *srv) {
                   config_plugin_value_tobool(
                     array_get_element_klen(cpv->v.a,
                       CONST_STR_LEN("server.absolute-dir-redirect")), 0);
+                break;
+              case 34:/* server.forward-reset */
+                srv->srvconf.forward_reset = (unsigned short)cpv->v.u;;
                 break;
               default:/* should not happen */
                 break;

--- a/src/connections.c
+++ b/src/connections.c
@@ -218,6 +218,12 @@ static void connection_handle_response_end_state(request_st * const r, connectio
 #endif
 		connection_set_state(r, CON_STATE_REQUEST_START);
 	} else {
+		if (r->resp_conn_reset) {
+			struct linger so_linger;
+			so_linger.l_onoff = 1;
+			so_linger.l_linger = 0;
+			(void)setsockopt(con->fd, SOL_SOCKET, SO_LINGER, &so_linger, sizeof so_linger);
+		}
 		connection_handle_shutdown(con);
 	}
 }

--- a/src/gw_backend.c
+++ b/src/gw_backend.c
@@ -2102,6 +2102,8 @@ static handler_t gw_backend_error(gw_handler_ctx * const hctx, request_st * cons
     if (hctx->backend_error) hctx->backend_error(hctx);
     http_response_backend_error(r);
     gw_connection_close(hctx, r);
+    if (r->con->srv->srvconf.forward_reset && r->resp_conn_reset)
+        return HANDLER_ERROR;
     return HANDLER_FINISHED;
 }
 
@@ -2401,6 +2403,10 @@ static handler_t gw_recv_response_error(gw_handler_ctx * const hctx, request_st 
               "socket: %s for %s?%.*s, terminating connection",
               proc->connection_name->ptr,
               r->uri.path.ptr, BUFFER_INTLEN_PTR(&r->uri.query));
+        }
+
+        if (r->resp_conn_reset) {
+            r->con->request.resp_conn_reset = 1;
         }
 
         return gw_backend_error(hctx, r); /* HANDLER_FINISHED */

--- a/src/http-header-glue.c
+++ b/src/http-header-glue.c
@@ -1288,6 +1288,9 @@ handler_t http_response_read(request_st * const r, http_response_opts * const op
                 if (buffer_is_blank(b))
                     chunk_buffer_yield(b); /*(improve large buf reuse)*/
                 return HANDLER_GO_ON;
+              case ECONNRESET:
+                  r->resp_conn_reset = 1;
+                  __attribute_fallthrough__
               default:
                 log_perror(r->conf.errh, __FILE__, __LINE__,
                   "read() %d %d", r->con->fd, fd);

--- a/src/reqpool.c
+++ b/src/reqpool.c
@@ -51,6 +51,7 @@ request_init_data (request_st * const r, connection * const con, server * const 
     r->con = con;
     r->tmp_buf = srv->tmp_buf;
     r->resp_body_scratchpad = -1;
+    r->resp_conn_reset = 0;
     r->server_name = &r->uri.authority;
 
     /* init plugin-specific per-request structures */
@@ -93,6 +94,7 @@ request_reset (request_st * const r)
     r->reqbody_length = 0;
     r->te_chunked = 0;
     r->resp_body_scratchpad = -1;
+    r->resp_conn_reset = 0;
     r->rqst_htags = 0;
 
     r->async_callback = 0;

--- a/src/request.h
+++ b/src/request.h
@@ -173,6 +173,7 @@ struct request_st {
     char resp_send_chunked;
     char resp_decode_chunked;
     char resp_header_repeated;
+    char resp_conn_reset; /*connection was reset by peer*/
 
     char loops_per_request;  /* catch endless loops in a single request */
     int8_t keep_alive; /* only request.c can enable it, all other just disable */


### PR DESCRIPTION
Let's add option to reset connection when backend connection is reset.
Useful when need to abort file download with failure indication (e.g. in web browser).