### PR TITLE
fix infinite reading  from CLOSE_WAIT socket

### DIFF
--- a/src/connections.c
+++ b/src/connections.c
@@ -1868,7 +1868,6 @@ connection_handle_read_post_state (request_st * const r)
             is_closed = 1;
     }
     else if (con->is_readable > 0) {
-        con->read_idle_ts = log_monotonic_secs;
         const off_t max_per_read =
           !(r->conf.stream_request_body /*(if not streaming request body)*/
             & (FDEVENT_STREAM_REQUEST|FDEVENT_STREAM_REQUEST_BUFMIN))
@@ -1884,6 +1883,7 @@ connection_handle_read_post_state (request_st * const r)
             is_closed = 1;
             break;
         default:
+	    con->read_idle_ts = log_monotonic_secs;
             break;
         }
 
@@ -1920,7 +1920,7 @@ connection_handle_read_post_state (request_st * const r)
         chunkqueue_remove_finished_chunks(cq);
     }
 
-    if (dst_cq->bytes_in == (off_t)r->reqbody_length) {
+    if (r->reqbody_length > 0 && dst_cq->bytes_in == (off_t)r->reqbody_length) {
         /* Content is ready */
         r->conf.stream_request_body &= ~FDEVENT_STREAM_REQUEST_POLLIN;
         if (r->state == CON_STATE_READ_POST) {


### PR DESCRIPTION
 CPU usage 100%  issue  was seen on CentOS-7.

"perf top "  output of lighttpd process:
```text
   2.67%  libssl.so.1.0.2k     [.] ssl3_read_bytes
   2.40%  lighttpd             [.] gw_handle_subrequest
   2.33%  [kernel]             [k] sysret_check
   2.31%  [kernel]             [k] tcp_recvmsg
   2.10%  [kernel]             [k] __fget_light
   2.00%  [kernel]             [k] ep_send_events_proc
   1.97%  mod_openssl.so       [.] connection_read_cq_ssl
   1.92%  [kernel]             [k] tcp_poll
   1.85%  lighttpd             [.] connection_set_fdevent_interest
   1.73%  libcrypto.so.1.0.2k  [.] ERR_clear_error
   1.70%  lighttpd             [.] connection_handle_read_post_state
   1.64%  lighttpd             [.] server_main_loop
   1.61%  [kernel]             [k] _raw_spin_lock_irqsave
   1.60%  libcrypto.so.1.0.2k  [.] CRYPTO_lock
   1.49%  libc-2.17.so         [.] __GI___libc_read
   1.47%  [kernel]             [k] select_estimate_accuracy
   1.47%  libssl.so.1.0.2k     [.] ssl3_read_n
   1.38%  [kernel]             [k] _raw_spin_unlock_irqrestore
   1.35%  [kernel]             [k] do_sync_read
   1.31%  [kernel]             [k] selinux_file_permission
   1.30%  [kernel]             [k] ktime_get_ts64
   1.27%  [kernel]             [k] ep_scan_ready_list.isra.7
   1.17%  [kernel]             [k] sys_epoll_wait
   1.12%  lighttpd             [.] server_run_con_queue
   1.10%  lighttpd             [.] fdevent_linux_sysepoll_poll
   1.10%  [kernel]             [k] system_call_after_swapgs
   1.06%  [kernel]             [k] __local_bh_enable_ip
   1.05%  [kernel]             [k] fsnotify
   1.01%  [kernel]             [k] sock_aio_read.part.9
   0.96%  [kernel]             [k] security_file_permission
   0.94%  [kernel]             [k] sys_read
   0.93%  [kernel]             [k] ep_poll
   0.90%  libcrypto.so.1.0.2k  [.] ERR_get_state
```

only one CLOSE-WAIT  connection was seen at that time:
```text
/ # ss -natp | grep lighttpd
LISTEN     0      512          *:80                       *:*                   users:(("lighttpd",pid=917,fd=6))
LISTEN     0      512    192.168.1.1:443                  *:*                   users:(("lighttpd",pid=917,fd=5))
LISTEN     0      512    192.168.1.1:443                  *:*                   users:(("lighttpd",pid=917,fd=4))
CLOSE-WAIT 0      0      192.168.1.1:443                192.168.1.39:41200      users:(("lighttpd",pid=917,fd=20))
```

According to the perf ouptut,   it seems that lighttpd ran into an infinite loop because of CLOSE-WAIT  ssl3 socket.
```text
gw_handle_subrequest
  reqbody_read
    connection_handle_read_post_state
      network_read
        connection_read_cq_ssl
          ssl3_read_bytes
```
