### PR TITLE
Fix websocket HTTP/2 to HTTP/1.1 proxy

### DIFF
--- a/src/mod_cgi.c
+++ b/src/mod_cgi.c
@@ -874,7 +874,7 @@ static int cgi_create_env(request_st * const r, plugin_data * const p, handler_c
 			if (!http_header_request_get(r, HTTP_HEADER_OTHER,
 			                             CONST_STR_LEN("Sec-WebSocket-Key")))
 				cgi_env_add(env, CONST_STR_LEN("HTTP_SEC_WEBSOCKET_KEY"),
-				                 CONST_STR_LEN("MDAwMDAwMDAwMDAwMDAwMAo="));
+				                 CONST_STR_LEN("MDAwMDAwMDAwMDAwMDAwMA=="));
 			/*(Upgrade and Connection should not exist for HTTP/2 request)*/
 			cgi_env_add(env, CONST_STR_LEN("HTTP_UPGRADE"), CONST_STR_LEN("websocket"));
 			cgi_env_add(env, CONST_STR_LEN("HTTP_CONNECTION"), CONST_STR_LEN("upgrade"));

--- a/src/mod_proxy.c
+++ b/src/mod_proxy.c
@@ -1013,7 +1013,7 @@ static handler_t proxy_create_env(gw_handler_ctx *gwhctx) {
 		if (!http_header_request_get(r, HTTP_HEADER_OTHER,
 		                             CONST_STR_LEN("Sec-WebSocket-Key")))
 			buffer_append_string_len(b, CONST_STR_LEN(
-			  "\r\nSec-WebSocket-Key: MDAwMDAwMDAwMDAwMDAwMAo="));
+			  "\r\nSec-WebSocket-Key: MDAwMDAwMDAwMDAwMDAwMA=="));
 		buffer_append_string_len(b, CONST_STR_LEN(
 		                              "\r\nUpgrade: websocket"
 		                              "\r\nConnection: close, upgrade\r\n\r\n"));


### PR DESCRIPTION
This PR fixes the websocket proxy from HTTP/2 client to HTTP/1.1 backend. Lighttpd adds a dummy Sec-WebSocket-Key value, but despite the comment, the decoded string is actually "0000000000000000\n" instead of "0000000000000000". My backend (python aiohttp library) rejects that value as being not 16 bytes long.
As the comment above the code correctly quotes, "the value of this header field MUST be a nonce consisting of a randomly selected ***16-byte value***".