### PR TITLE
Enable partial masking of IP addresses in access logs

### DIFF
--- a/doc/config/conf.d/access_log.conf
+++ b/doc/config/conf.d/access_log.conf
@@ -13,7 +13,8 @@ accesslog.filename          = log_root + "/access.log"
 
 ##
 ## The default format produces CLF compatible output.
-## For available parameters see access.txt 
+## For available parameters see
+## https://wiki.lighttpd.net/mod_accesslog
 ##
 #accesslog.format = "%h %l %u %t \"%r\" %b %>s \"%{User-Agent}i\" \"%{Referer}i\""
 

--- a/src/mod_accesslog.c
+++ b/src/mod_accesslog.c
@@ -1,5 +1,6 @@
 #include "first.h"
 
+#include "sys-socket.h"
 #include "sys-time.h"
 
 #include "base.h"
@@ -10,6 +11,7 @@
 #include "http_header.h"
 #include "response.h"
 #include "sock_addr.h"
+#include "sock_addr_cache.h"
 
 #include "plugin.h"
 
@@ -18,6 +20,7 @@
 
 #include <stdlib.h>
 #include <string.h>
+#include <errno.h>
 #include <fcntl.h>
 #include <unistd.h>
 
@@ -570,8 +573,49 @@ static format_fields * mod_accesslog_process_format(const char * const format, c
 				} else if (FORMAT_HEADER == f->field
 				           || FORMAT_RESPONSE_HEADER == f->field) {
 					f->opt = http_header_hkey_get(BUF_PTR_LEN(fstr));
-				} else if (FORMAT_REMOTE_HOST == f->field) {
+				} else if (FORMAT_REMOTE_HOST == f->field
+					   || FORMAT_REMOTE_ADDR == f->field) {
 					f->field = FORMAT_REMOTE_ADDR;
+					if (!buffer_is_blank(fstr)) {
+						const char * const ptr = fstr->ptr;
+						char * tmp;
+						uint8_t shift = 0;
+						uint32_t i = 0;
+						uint32_t len = buffer_clen(fstr);
+						int32_t v;
+						while (i < len) {
+							if (0 == strncmp(ptr + i, "v4:", 3)) {
+								shift = 0;
+							} else if (0 == strncmp(ptr + i, "v6:", 3)) {
+								shift = 8;
+							} else {
+								log_error(srv->errh, __FILE__, __LINE__,
+									"invalid format %%{v[46]:numbits[,...]}a: %s", format);
+								mod_accesslog_free_format_fields(parsed_format);
+								return NULL;
+							}
+							i += 3;
+							v = strtol(ptr + i, &tmp, 0);
+							if (ERANGE == errno || EINVAL == errno || v < 0 || v > (shift ? 128 : 32)) {
+								log_error(srv->errh, __FILE__, __LINE__,
+									"invalid numeric value %%{v[46]:numbits[,...]}a: %s", format);
+								mod_accesslog_free_format_fields(parsed_format);
+								return NULL;
+							}
+							i = tmp - ptr;
+							if (i < len) {
+								if (',' != ptr[i]) {
+								log_error(srv->errh, __FILE__, __LINE__,
+									"expected , after numeric value %%{v[46]:numbits[,...]}a: %s", format);
+								mod_accesslog_free_format_fields(parsed_format);
+								return NULL;
+								}
+							       ++i;
+							}
+							f->opt &= ~(255 << shift);
+							f->opt |= v << shift;
+						}
+					}
 				} else if (FORMAT_REMOTE_USER == f->field) {
 					f->field = FORMAT_ENV;
 					buffer_copy_string_len(fstr, CONST_STR_LEN("REMOTE_USER"));
@@ -833,7 +877,20 @@ log_access_record_cold (buffer * const b, const request_st * const r,
     }
 }
 
+static void mask(void * what, int32_t bytes, uint32_t mask_bits) {
+	while (--bytes >= 0 && mask_bits > 0) {
+		if (mask_bits >= 8) {
+			((char*) what)[bytes] = 0;
+			mask_bits -= 8;
+		} else {
+			((char*) what)[bytes] &= ~((1 << mask_bits) - 1);
+			mask_bits = 0;
+		}
+	}
+}
+
 static int log_access_record (const request_st * const r, buffer * const b, format_fields * const parsed_format, esc_fn_t esc) {
+	buffer tmp = {0};
 	const buffer *vb;
 	unix_timespec64_t ts = { 0, 0 };
 	int flush = 0;
@@ -875,7 +932,38 @@ static int log_access_record (const request_st * const r, buffer * const b, form
 			/*case FORMAT_REMOTE_HOST:*/
 		  #endif
 			case FORMAT_REMOTE_ADDR:
-				buffer_append_string_buffer(b, r->dst_addr_buf);
+				switch (((struct sockaddr*)r->dst_addr)->sa_family) {
+				  case AF_INET:
+				    if (f->opt & 255) {
+					sock_addr masked = *(sock_addr*)r->dst_addr;
+					mask(&masked.ipv4.sin_addr.s_addr, 4, f->opt & 255);
+					if (0 == sock_addr_cache_inet_ntop_copy_buffer(&tmp, &masked)) {
+						buffer_append_string_buffer(b, &tmp);
+					} else {
+						buffer_append_string_buffer(b, r->dst_addr_buf);
+					}
+				    } else {
+					buffer_append_string_buffer(b, r->dst_addr_buf);
+				    }
+				    break;
+				 #ifdef HAVE_IPV6
+				  case AF_INET6:
+				    if (f->opt & (255<<8)) {
+					sock_addr masked = *(sock_addr*)r->dst_addr;
+					mask(&masked.ipv6.sin6_addr.s6_addr, 16, (f->opt & (255<<8)) >> 8);
+					if (0 == sock_addr_cache_inet_ntop_copy_buffer(&tmp, &masked)) {
+						buffer_append_string_buffer(b, &tmp);
+					} else {
+						buffer_append_string_buffer(b, r->dst_addr_buf);
+					}
+				    } else {
+					buffer_append_string_buffer(b, r->dst_addr_buf);
+				    }
+				    break;
+				 #endif
+				  default:
+				    buffer_append_string_buffer(b, r->dst_addr_buf);
+				}
 				break;
 			case FORMAT_HTTP_HOST:
 				accesslog_append_buffer(b, &r->uri.authority, esc);
@@ -918,6 +1006,7 @@ static int log_access_record (const request_st * const r, buffer * const b, form
 				break;
 			}
 	}
+	buffer_free_ptr(&tmp);
 
 	return flush;
 }

--- a/src/mod_accesslog.c
+++ b/src/mod_accesslog.c
@@ -10,7 +10,6 @@
 #include "http_header.h"
 #include "response.h"
 #include "sock_addr.h"
-#include "sock_addr_cache.h"
 
 #include "plugin.h"
 
@@ -889,7 +888,7 @@ accesslog_append_addr (buffer * const b, const request_st * const r,
 	  case AF_INET6:
 	 #endif
 	    if (0 != sock_addr_mask_lower_bits(&masked, (sock_addr*)r->dst_addr, f->opt & 0xff, (f->opt >> 8) & 0xff)
-			&& 0 == sock_addr_cache_inet_ntop_copy_buffer(&tmp, &masked)) {
+			&& 0 == sock_addr_inet_ntop_copy_buffer(&tmp, &masked)) {
 		buffer_append_string_buffer(b, &tmp);
 		buffer_free_ptr(&tmp);
 		break;

--- a/src/sock_addr.h
+++ b/src/sock_addr.h
@@ -50,6 +50,8 @@ int sock_addr_is_addr_port_eq (const sock_addr *saddr1, const sock_addr *saddr2)
 __attribute_pure__
 int sock_addr_is_addr_eq_bits(const sock_addr * restrict a, const sock_addr * restrict b, int bits);
 
+int sock_addr_mask_lower_bits(sock_addr * dest, const sock_addr * src, unsigned int v4bits, unsigned int v6bits);
+
 void sock_addr_set_port (sock_addr * restrict saddr, unsigned short port);
 
 int sock_addr_assign (sock_addr * restrict saddr, int family, unsigned short nport, const void * restrict naddr);


### PR DESCRIPTION
This PR is inspired by mod_log_ipmask for apache. It was written from scratch by myself (as should be obvious from the git history), i. e. is not based on the actual code of mod_log_ipmask.

It adds an optional format parameter to the %a / %h placeholders in the accesslog.format config option. The parameter can specify how many trailing bits of the client IP address to mask (i. e. set to 0). Separate values can be set for IPv4 and IPv6. Both default to 0, meaning no masking, i. e. the behaviour is compatible with previous versions.