### PR TITLE
[dirlisting] Add dark mode support

### DIFF
--- a/src/mod_dirlisting.c
+++ b/src/mod_dirlisting.c
@@ -953,7 +953,14 @@ static void http_list_directory_header(request_st * const r, const handler_ctx *
 				" color: #787878;"
 				" padding-top: 4px;"
 				"}\n"
+				"@media (prefers-color-scheme: dark) {\n"
+				" a, a:active {color: #9E9EFF;}\n"
+				" a:visited {color: #D0ADF0;}\n"
+				" body, div.list {background-color: transparent;}\n"
+				" div.foot {color: #878787;}\n"
+				"}\n"
 				"</style>\n"
+				"<meta name=\"color-scheme\" content=\"light dark\">\n"
 			));
 		}
 


### PR DESCRIPTION
This adds dark mode support to lighttpd's dirlisting generated pages.

Nowadays files transferred to browser via text/* MIME are also getting
automatic dark mode by the browsers so this makes lighttpd's dirlisting
compatible with those features of the browsers.

https://github.com/lighttpd/lighttpd1.4/assets/833473/d4dac3f5-442d-43ec-859f-ff313ba25f94

lighttpd 2.0 version of the patch: https://github.com/lighttpd/lighttpd2/pull/13

(build instructions self note for future)
```
meson setup --buildtype debugoptimized build
ninja -C build && build/src/lighttpd -m build/src -f /etc/lighttpd/lighttpd.conf -D
```

