### PR TITLE
[autotools] Prefer libpcre.pc to pcre-config

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -932,11 +932,16 @@ if test "$WITH_PCRE" != no; then
     PCRE_LIB="-L$WITH_PCRE/lib -lpcre"
     CPPFLAGS="$CPPFLAGS -I$WITH_PCRE/include"
   else
-    AC_PATH_PROG([PCRECONFIG], [pcre-config])
-    if test -n "$PCRECONFIG"; then
-      PCRE_LIB=`"$PCRECONFIG" --libs`
-      CPPFLAGS="$CPPFLAGS `"$PCRECONFIG" --cflags`"
-    fi
+    PKG_CHECK_MODULES([PCRE], [libpcre], [
+      PCRE_LIB="$PCRE_LIBS"
+      CPPFLAGS="$CPPFLAGS $PCRE_CFLAGS"
+    ], [
+      AC_PATH_PROG([PCRECONFIG], [pcre-config])
+      if test -n "$PCRECONFIG"; then
+        PCRE_LIB=`"$PCRECONFIG" --libs`
+        CPPFLAGS="$CPPFLAGS `"$PCRECONFIG" --cflags`"
+      fi
+    ])
   fi
 
   if test -z "$PCRE_LIB"; then


### PR DESCRIPTION
Prefer pkg-config to configure for pcre as it seems more reliable in more situations, like cross-compilation.

---

I was running into some issues with a Yocto Project recipe, this solved that issue. I also see it had been done for the other build-systems, so figured autotools could follow suite.