### PR TITLE
[h2] fix spurious connection resets with zero log_monotonic_secs

### DIFF
--- a/src/h2.c
+++ b/src/h2.c
@@ -2227,7 +2227,8 @@ h2_init_con (request_st * const restrict h2r, connection * const restrict con)
     h2c->s_initial_window_size   = 65536; /* SETTINGS_INITIAL_WINDOW_SIZE    */
     h2c->s_max_frame_size        = 16384; /* SETTINGS_MAX_FRAME_SIZE         */
     h2c->s_max_header_list_size  = ~0u;   /* SETTINGS_MAX_HEADER_LIST_SIZE   */
-    h2c->sent_settings           = log_monotonic_secs;/*(send SETTINGS below)*/
+    /* used both as boolean and timestamp, avoid incorrect protocol handling when monotonic clock starts at zero */
+    h2c->sent_settings           = log_monotonic_secs ? log_monotonic_secs : 1;/*(send SETTINGS below)*/
 
     lshpack_dec_init(&h2c->decoder);
     lshpack_enc_init(&h2c->encoder);


### PR DESCRIPTION
- apparently monotonic clock starts at zero on Cloud Run's gVisor
  - potentially affects other hypervisors/container-emulations
- h2 sent_settings protocol flag was used both as bool and timestamp which lead to a protocol error[¹](https://git.lighttpd.net/lighttpd/lighttpd1.4/src/a578c50d78a3085fe78d0ed97fb3e42affe9936a/src/h2.c#L1047-L1048) when receiving a settings ACK while log_monotonic_secs was still zero
- fixed by using at least 1s as timestamp for sent_settings