### PR TITLE
[script + doc] Update tar.bz2 mime type

### DIFF
--- a/doc/scripts/create-mime.conf.pl
+++ b/doc/scripts/create-mime.conf.pl
@@ -177,10 +177,11 @@ add(".mjs", "text/javascript");
 
 # other useful mappings
 my %useful = (
+	".tgz"     => "application/x-gtar-compressed",
 	".tar.gz"  => "application/x-gtar-compressed",
 	".gz"      => "application/gzip",
-	".tbz"     => "application/x-gtar-compressed",
-	".tar.bz2" => "application/x-gtar-compressed",
+	".tbz"     => "application/x-bzip-compressed-tar",
+	".tar.bz2" => "application/x-bzip-compressed-tar",
 	".bz2"     => "application/x-bzip2",
 	".log"     => "text/plain",
 	".conf"    => "text/plain",


### PR DESCRIPTION
# Changes

 * Unify the content type of gzip compressed tars to application/x-gtar-compressed
 * Unify the content type of bzip2 compressed tars to application/x-bzip-compressed-tar
 * Add .tgz to useful_types because it being missing when .tar.gz was there annoyed to perfectionist in me

# Reasoning

Unfortunately the MIME types used for compressed tars vary quite a lot.  
Below this I am trying to detail the pros and cons of the various MIME types I found being used, as well as my reasoning for choosing the ones I ultimately chose.

I looked at the default mime.types files for [Debian](https://packages.debian.org/trixie/media-types), [Fedora](https://packages.fedoraproject.org/pkgs/mailcap/mailcap/), [OpenBSD](https://cvsweb.openbsd.org/cgi-bin/cvsweb/src/share/misc/mime.types), and [Apache](https://github.com/apache/httpd/blob/trunk/docs/conf/mime.types).  
I also just googled around for a while and looked at lots of projects, of which I remember far too few to list them here, to get a rough feeling for which MIME types are used how much.

I also looked at [xdg-shared-mime-info](https://gitlab.freedesktop.org/xdg/shared-mime-info/-/blob/master/data/freedesktop.org.xml.in?ref_type=heads) to see what they use.


Finding projects containing their own tar.bz2 mappings was pretty challenging, so I don't have much data to base my usage guesses on.  
I still tried my best regardless, but the result may not be perfect.


## Gzip

### `application/gzip`
Pros
 * The only actually IANA registered type
 * Used by Fedora

Cons
 * Does not give any information about the type of the compressed file, which some people argue is more important than the compression used.
 * Not very widely used for tgz and tar.gz files

### `application/x-gtar-compressed` (Used in this PR)
Pros
 * Currently used(would't be a change, and thus has no potential to break things)
 * Used by Debian
 * Seems to be the most widely used and recognized from what I found(I didn't make a detailed statistic I could use as a source)

Cons
 * Does not specify the compression algorithm used

### `application/x-tgz`
Pros
 * Compact
 * Very Precise

Cons
 * Not very widely used

### `application/x-compressed-tar`
Pros
 * Used by XDG

Cons
 * Does not specify the compression algorithm
 * From what I found its not very widely used


## Bzip2

### `application/x-bzip2`
Pros
 * None?
 * This is implicitly used by Fedora and Apache, but I don't think that matters all that much if it isn't even explicit.

Cons
 * Not very widely used
 * Doesn't describe the format of the compressed data

### `application/x-gtar-compressed`
Pros
 * Currently used by lighttpd(Thus wouldn't be a change that could cause breakage)

Cons
 * Does not describe the compression format used
 * I could not find any other project using it

### `application/x-bzip-compressed-tar` (Used in this PR)
Pros
 * Recognized as an alias by XDG
 * The most widely used type, as far as I can tell

Cons
 * Does not specify the bzip version

### `application/x-bzip2-compressed-tar`
Pros
 * The most precise type
 * Used by XDG

Cons
 * Not as widely used as `application/x-bzip-compressed-tar`

# Related question and notice

## Wiki Page

The [mimetype.assign wiki page config sample](https://redmine.lighttpd.net/projects/lighttpd/wiki/Mimetype_assignDetails#Configuration-Sample) contains a few minor issues related to compressed tars.  
These aren't important enough for me to want to learn to use redmine and create an account to edit the lighttpd wiki because of it.  
But I still thought I should mention them somewhere, so here they are.

 * .gz is above .tar.gz, causing .tar.gz files to be sent as `application/x-gzip`
 * .bz2 is above .tar.bz2, causing .tar.bz2 files to be sent as `application/x-bzip`
 * .bz2 uses the type `application/x-bzip`, despite all of the mime.types files I checked, which contain bz2 at all, using `application/x-bzip2`. Those are Fedora, Apache, and XDG. Lighttpd also uses `application/x-bzip2` by default.
 * .gz uses the MIME type `application/x-gzip` despite the officially registered `application/gzip` type now being registered for quite a while, and being more widely supported as far as I can tell
 * .tgz and .tar.gz use the type `application/x-tgz`, which seems to be relatively uncommon as far as I can tell.

As a side note, this example already uses `application/x-bzip-compressed-tar` for bzip compressed tars.


## Future PR

The perfectionist in me wanted to check all the default types in [configfile.c](https://github.com/lighttpd/lighttpd1.4/blob/master/src/configfile.c) against the Debian and Fedora mime.types files and add those who are missing from one or both of those to useful_types.  
I held back on that, because it would be out of scope for this PR, but I wanted to ask a few things about this:  
 1. If I create a PR for that, would that have any chance of being accepted? It would likely only add single-digit mappings.
 2. If I do that, should I add those entries that one distro is missing, or only those both are missing?
 3. Is there any other distro I should check against as well?