### PR TITLE
Unifying chunk buffer size logic

### DIFF
--- a/src/chunk.c
+++ b/src/chunk.c
@@ -352,7 +352,7 @@ __attribute_returns_nonnull__
 static buffer * chunk_buffer_acquire_sz(const size_t sz) {
     chunk *c;
     buffer *b;
-    if (sz <= (chunk_buf_sz|1)) {
+    if (sz <= chunk_buf_sz) {
         if (chunks) {
             c = chunks;
             chunks = c->next;
@@ -368,7 +368,7 @@ static buffer * chunk_buffer_acquire_sz(const size_t sz) {
              * (sz & ~1uL) relies on buffer_realloc() adding +1 *and* on callers
              * of this func never passing power-2 + 1 sz unless direct caller
              * adds +1 for '\0', as is done in chunk_buffer_prepare_append() */
-            c = chunk_init_sz(((sz&~1uL)+(chunk_buf_sz-1)) & ~(chunk_buf_sz-1));
+            c = chunk_init_sz((sz + (chunk_buf_sz-1)) & ~(chunk_buf_sz-1));
         }
     }
     c->next = chunk_buffers;
@@ -432,7 +432,7 @@ size_t chunk_buffer_prepare_append(buffer * const b, size_t sz) {
 __attribute_noinline__
 __attribute_returns_nonnull__
 static chunk * chunk_acquire(size_t sz) {
-    if (sz <= (chunk_buf_sz|1)) {
+    if (sz <= chunk_buf_sz) {
         if (chunks) {
             chunk *c = chunks;
             chunks = c->next;


### PR DESCRIPTION
Hi, I'm an engineer who use your lighttpd1.4
It would not be a bug on your side. But based on my experience, I think it can cause critical issue.

# [1] Issue in the original code
1
Oversized buffer size logic is different between **chunk_buffer_acquire_sz()** and **chunk_acquire().**

2
According to **chunk_acquire()**
Every number of sz become size up to the nearest multiple number of **chunk_buf_sz.**
But only when sz is 8193, it size down to the nearest multiple number of **chunk_buf_sz** 8192.

# [2] What I fix
I unify all the rule of sizing chunk buffer as sizing up to the nearest multiple number of **chunk_buf_sz.**
I know you try to avoid excess allocation by sizing down sz when sz is **chunk_buf_sz*N+1**
I explain below why I fixed it this way.


# [3] Why I do this
1
Until recently, I use lighttpd 1.4.52 which is 7 years ago version.
With this version when ethernet speed is over 1Gbps, lighttpd fail to fork because of lack of memory.
I found out **chunkqueue_append_buffer_open_sz()** in chunk.c was related with it
It allocated new memory whenever sz is 4KB and sz is always 4KB when using 1Gbps ethernet.
So it caused memory leak.
I know it's not directly related with this issue, but these two issue are related with allocating additional space for '\0'
So it would be better to give additional space for '\0' regardless of the size of sz.

2
As I understand, it doesn't give extra space for '\0' when sz is **chunk_buf_sz*N+1**. 
But it allocate extra space if sz is not **chunk_buf_sz*N+1**. So I think it lose some consistency.
 
Thank you




 