### PR TITLE
close unused socket after graceful restart

### DIFF
--- a/src/network.c
+++ b/src/network.c
@@ -984,11 +984,20 @@ int network_init(server *srv, int stdin_fd) {
             }
         }
 
-        /* reset sidx of any graceful sockets not explicitly listed in config */
+        /* close any sockets(exclude inherited ones) not explicitly listed in config */
         for (uint32_t i = 0; i < srv->srv_sockets.used; ++i) {
             if ((unsigned short)~0u == srv->srv_sockets.ptr[i]->sidx) {
-                srv->srv_sockets.ptr[i]->sidx = 0;
-                srv->srv_sockets.ptr[i]->is_ssl = p->defaults.ssl_enabled;
+                server_socket *srv_socket = srv->srv_sockets.ptr[i];
+                if (srv_socket->fd != -1) {
+                    fdio_close_socket(srv_socket->fd);
+                }
+                buffer_free(srv_socket->srv_token);
+                free(srv_socket);
+
+                memmove(srv->srv_sockets.ptr + i, srv->srv_sockets.ptr + i + 1,
+                        (srv->srv_sockets.used - i - 1) * sizeof(*srv->srv_sockets.ptr));
+                --srv->srv_sockets.used;
+                --i;
             }
         }
 


### PR DESCRIPTION
This PR addresses an issue where network ports (sockets) are not properly released after a graceful restart triggered by SIGUSR1 

While the commit [6c1e6e66](https://github.com/lighttpd/lighttpd1.4/commit/6c1e6e660e97318ed10360002130f03ffbc4a6ae) introduced the core logic for graceful restarts, a limitation in the current implementation prevents the process from closing the old listening sockets. This can lead to port exhaustion or conflicts when multiple restarts occur in a short period.

Changed:
* Refactored socket management: Instead of binding `srv` to sockets during the graceful restart phase, the binding now occurs during network initialization. This allows the system to accurately track which sockets are active in the updated configuration.
* Resource Leak Fix: Added logic to identify and close unused sockets immediately after server initialization, ensuring that redundant ports are released to the system.