### PR TITLE
Cap snprintf return value in mod_maxminddb to prevent stack over-read

### DIFF
--- a/src/mod_maxminddb.c
+++ b/src/mod_maxminddb.c
@@ -377,9 +377,11 @@ geoip2_env_set (request_st * const r, array * const env,
         break;
       case MMDB_DATA_TYPE_DOUBLE:
         vlen = snprintf(buf, sizeof(buf), "%.5f", data->double_value);
+        if (vlen >= sizeof(buf)) vlen = sizeof(buf) - 1;
         break;
       case MMDB_DATA_TYPE_FLOAT:
         vlen = snprintf(buf, sizeof(buf), "%.5f", data->float_value);
+        if (vlen >= sizeof(buf)) vlen = sizeof(buf) - 1;
         break;
       case MMDB_DATA_TYPE_INT32:
         vlen = li_itostrn(buf, sizeof(buf), data->int32);


### PR DESCRIPTION
snprintf at lines 379/382 returns the number of characters that would have been written, which can exceed sizeof(buf) for large double/float values. This value is used directly as the data length for http_header_env_set, causing a stack buffer over-read. Cap vlen to sizeof(buf) - 1 after each snprintf call.