### PR TITLE
[mod_wstunnel] RFC 6455 §5 compliance

### DIFF
--- a/src/mod_wstunnel.c
+++ b/src/mod_wstunnel.c
@@ -1068,6 +1068,21 @@ static int recv_ietf_00(handler_ctx *hctx) {
 #define MOD_WEBSOCKET_FRAME_LEN16_CNT  2
 #define MOD_WEBSOCKET_FRAME_LEN63_CNT  8
 
+static int is_control_frame(const handler_ctx * const hctx) {
+    return hctx->frame.type == MOD_WEBSOCKET_FRAME_TYPE_PING
+        || hctx->frame.type == MOD_WEBSOCKET_FRAME_TYPE_PONG
+        || hctx->frame.type == MOD_WEBSOCKET_FRAME_TYPE_CLOSE;
+}
+
+static int check_control_frame_size(const handler_ctx * const hctx) {
+    if (is_control_frame(hctx)
+        && hctx->frame.ctl.siz >= MOD_WEBSOCKET_FRAME_LEN16) {
+        DEBUG_LOG_ERR("%s", "control frame size is invalid");
+        return -1;
+    }
+    return 0;
+}
+
 static int send_rfc_6455(handler_ctx *hctx, mod_wstunnel_frame_type_t type, const char *payload, size_t siz) {
     char mem[10];
     size_t len;
@@ -1159,6 +1174,14 @@ static int recv_rfc_6455(handler_ctx *hctx) {
         for (uint32_t i = 0; i < flen; ) {
             switch (hctx->frame.state) {
             case MOD_WEBSOCKET_FRAME_STATE_INIT:
+                if ((frame[i] & 0x70) != 0) {
+                    DEBUG_LOG_ERR("%s", "reserved bits are set");
+                    return -1;
+                }
+                if ((frame[i] & 0x08) && 0 == (frame[i] & 0x80)) {
+                    DEBUG_LOG_ERR("%s", "control frame is fragmented");
+                    return -1;
+                }
                 switch (frame[i] & 0x0f) {
                 case MOD_WEBSOCKET_OPCODE_CONT:
                     DEBUG_LOG_DEBUG("%s", "type = continue");
@@ -1208,12 +1231,20 @@ static int recv_rfc_6455(handler_ctx *hctx) {
                     hctx->frame.state = MOD_WEBSOCKET_FRAME_STATE_READ_MASK;
                 }
                 else if (hctx->frame.ctl.siz == MOD_WEBSOCKET_FRAME_LEN16) {
+                    if (is_control_frame(hctx)) {
+                        DEBUG_LOG_ERR("%s", "control frame size is invalid");
+                        return -1;
+                    }
                     hctx->frame.ctl.siz = 0;
                     hctx->frame.ctl.siz_cnt = MOD_WEBSOCKET_FRAME_LEN16_CNT;
                     hctx->frame.state =
                         MOD_WEBSOCKET_FRAME_STATE_READ_EX_LENGTH;
                 }
                 else if (hctx->frame.ctl.siz == MOD_WEBSOCKET_FRAME_LEN63) {
+                    if (is_control_frame(hctx)) {
+                        DEBUG_LOG_ERR("%s", "control frame size is invalid");
+                        return -1;
+                    }
                     hctx->frame.ctl.siz = 0;
                     hctx->frame.ctl.siz_cnt = MOD_WEBSOCKET_FRAME_LEN63_CNT;
                     hctx->frame.state =
@@ -1222,11 +1253,17 @@ static int recv_rfc_6455(handler_ctx *hctx) {
                 else {
                     DEBUG_LOG_DEBUG("specified payload size=%llx",
                                     (unsigned long long)hctx->frame.ctl.siz);
+                    if (0 != check_control_frame_size(hctx)) return -1;
                     hctx->frame.state = MOD_WEBSOCKET_FRAME_STATE_READ_MASK;
                 }
                 i++;
                 break;
             case MOD_WEBSOCKET_FRAME_STATE_READ_EX_LENGTH:
+                if (hctx->frame.ctl.siz_cnt == MOD_WEBSOCKET_FRAME_LEN63_CNT
+                    && (frame[i] & 0x80)) {
+                    DEBUG_LOG_ERR("%s", "frame size MSB is set");
+                    return -1;
+                }
                 hctx->frame.ctl.siz =
                     (hctx->frame.ctl.siz << 8) + (frame[i] & 0xff);
                 hctx->frame.ctl.siz_cnt--;
@@ -1239,6 +1276,7 @@ static int recv_rfc_6455(handler_ctx *hctx) {
                     }
                     DEBUG_LOG_DEBUG("specified payload size=%llx",
                                     (unsigned long long)hctx->frame.ctl.siz);
+                    if (0 != check_control_frame_size(hctx)) return -1;
                     hctx->frame.state = MOD_WEBSOCKET_FRAME_STATE_READ_MASK;
                 }
                 i++;

--- a/src/mod_wstunnel.c
+++ b/src/mod_wstunnel.c
@@ -163,6 +163,7 @@ typedef struct {
     mod_wstunnel_frame_state_t state;
     mod_wstunnel_frame_control_t ctl;
     mod_wstunnel_frame_type_t type, type_before, type_backend;
+    int ctl_frame;
     buffer *payload;
 } mod_wstunnel_frame_t;
 
@@ -1068,21 +1069,6 @@ static int recv_ietf_00(handler_ctx *hctx) {
 #define MOD_WEBSOCKET_FRAME_LEN16_CNT  2
 #define MOD_WEBSOCKET_FRAME_LEN63_CNT  8
 
-static int is_control_frame(const handler_ctx * const hctx) {
-    return hctx->frame.type == MOD_WEBSOCKET_FRAME_TYPE_PING
-        || hctx->frame.type == MOD_WEBSOCKET_FRAME_TYPE_PONG
-        || hctx->frame.type == MOD_WEBSOCKET_FRAME_TYPE_CLOSE;
-}
-
-static int check_control_frame_size(const handler_ctx * const hctx) {
-    if (is_control_frame(hctx)
-        && hctx->frame.ctl.siz >= MOD_WEBSOCKET_FRAME_LEN16) {
-        DEBUG_LOG_ERR("%s", "control frame size is invalid");
-        return -1;
-    }
-    return 0;
-}
-
 static int send_rfc_6455(handler_ctx *hctx, mod_wstunnel_frame_type_t type, const char *payload, size_t siz) {
     char mem[10];
     size_t len;
@@ -1178,7 +1164,8 @@ static int recv_rfc_6455(handler_ctx *hctx) {
                     DEBUG_LOG_ERR("%s", "reserved bits are set");
                     return -1;
                 }
-                if ((frame[i] & 0x08) && 0 == (frame[i] & 0x80)) {
+                hctx->frame.ctl_frame = (frame[i] & 0x08);
+                if (hctx->frame.ctl_frame && 0 == (frame[i] & 0x80)) {
                     DEBUG_LOG_ERR("%s", "control frame is fragmented");
                     return -1;
                 }
@@ -1231,7 +1218,7 @@ static int recv_rfc_6455(handler_ctx *hctx) {
                     hctx->frame.state = MOD_WEBSOCKET_FRAME_STATE_READ_MASK;
                 }
                 else if (hctx->frame.ctl.siz == MOD_WEBSOCKET_FRAME_LEN16) {
-                    if (is_control_frame(hctx)) {
+                    if (hctx->frame.ctl_frame) {
                         DEBUG_LOG_ERR("%s", "control frame size is invalid");
                         return -1;
                     }
@@ -1241,7 +1228,7 @@ static int recv_rfc_6455(handler_ctx *hctx) {
                         MOD_WEBSOCKET_FRAME_STATE_READ_EX_LENGTH;
                 }
                 else if (hctx->frame.ctl.siz == MOD_WEBSOCKET_FRAME_LEN63) {
-                    if (is_control_frame(hctx)) {
+                    if (hctx->frame.ctl_frame) {
                         DEBUG_LOG_ERR("%s", "control frame size is invalid");
                         return -1;
                     }
@@ -1253,30 +1240,21 @@ static int recv_rfc_6455(handler_ctx *hctx) {
                 else {
                     DEBUG_LOG_DEBUG("specified payload size=%llx",
                                     (unsigned long long)hctx->frame.ctl.siz);
-                    if (0 != check_control_frame_size(hctx)) return -1;
                     hctx->frame.state = MOD_WEBSOCKET_FRAME_STATE_READ_MASK;
                 }
                 i++;
                 break;
             case MOD_WEBSOCKET_FRAME_STATE_READ_EX_LENGTH:
-                if (hctx->frame.ctl.siz_cnt == MOD_WEBSOCKET_FRAME_LEN63_CNT
-                    && (frame[i] & 0x80)) {
-                    DEBUG_LOG_ERR("%s", "frame size MSB is set");
-                    return -1;
-                }
                 hctx->frame.ctl.siz =
                     (hctx->frame.ctl.siz << 8) + (frame[i] & 0xff);
                 hctx->frame.ctl.siz_cnt--;
                 if (hctx->frame.ctl.siz_cnt <= 0) {
-                    if (hctx->frame.type == MOD_WEBSOCKET_FRAME_TYPE_PING &&
-                        hctx->frame.ctl.siz > MOD_WEBSOCKET_BUFMAX) {
-                        DEBUG_LOG_WARN("frame size has been exceeded: %x",
-                                       MOD_WEBSOCKET_BUFMAX);
+                    if (hctx->frame.ctl.siz >> 63) {
+                        DEBUG_LOG_ERR("%s", "frame size MSB is set");
                         return -1;
                     }
                     DEBUG_LOG_DEBUG("specified payload size=%llx",
                                     (unsigned long long)hctx->frame.ctl.siz);
-                    if (0 != check_control_frame_size(hctx)) return -1;
                     hctx->frame.state = MOD_WEBSOCKET_FRAME_STATE_READ_MASK;
                 }
                 i++;


### PR DESCRIPTION
I was investigating an unusual memory consumption (when `server.stream-request-body = 1`), noticed minor compliance issues so made some changes according to the RFC, to reject malformed input rather than silently accepting it:

- Reject 64-bit payload length with the MSB set (RFC 6455 §5.2).
- Reject Ping/Pong/Close payloads longer than 125 bytes (RFC 6455 §5.5).
- Reject fragmented control frames (RFC 6455 §5.5).
- Reject RSV1/RSV2/RSV3 bits when no extension is negotiated (RFC 6455 §5.2).