### PR TITLE
[mod_extforward] reject out-of-range netmask bits

### DIFF
--- a/src/mod_extforward.c
+++ b/src/mod_extforward.c
@@ -317,6 +317,13 @@ static void * mod_extforward_parse_forwarder(server *srv, const array *forwarder
             free(fwd);
             return NULL;
         }
+        /* netmask bits must fit address family (IPv4 32, IPv6 128) */
+        if (nm_bits > (sock_addr_get_family(&sm->addr) == AF_INET ? 32 : 128)) {
+            log_error(srv->errh, __FILE__, __LINE__,
+              "ERROR: invalid netmask: %s", ds->key.ptr);
+            free(fwd);
+            return NULL;
+        }
         buffer_clear(&ds->value);
         /* empty is untrusted,
          * e.g. if subnet (incorrectly) appears in X-Forwarded-For */

--- a/src/rand.c
+++ b/src/rand.c
@@ -35,6 +35,7 @@
 #include <nettle/knuth-lfib.h>
 #include <nettle/arcfour.h>
 #include <nettle/yarrow.h>
+#include <nettle/version.h>
 #endif
 #ifdef USE_MBEDTLS_CRYPTO
 #undef USE_WOLFSSL_CRYPTO
@@ -261,7 +262,11 @@ li_arcfour_init_random_key_hashed(struct arcfour_ctx *ctx)
     memset(buf, 0, sizeof(buf));
     sha256_init(&hash);
     sha256_update(&hash, length, key);
+  #if NETTLE_VERSION_MAJOR >= 4
+    sha256_digest(&hash, digest);
+  #else
     sha256_digest(&hash, SHA256_DIGEST_SIZE, digest);
+  #endif
     nettle_arcfour_set_key(ctx, SHA256_DIGEST_SIZE, digest);
     nettle_arcfour_crypt(ctx, sizeof(buf), buf, buf);
     nettle_arcfour_crypt(ctx, sizeof(buf), buf, buf);


### PR DESCRIPTION
CIDR netmask bits were checked only against a lower bound, so configs such as "10.0.0.0/9999" were silently accepted.  This patch will reject bits greater than the address family maximum (/32 for IPv4, /128 for IPv6).

---

/0 is handled by `extforward.forwarder = ( "all" => "trust" )`