### PR TITLE
[core] support directory symlinks in fs_win32_readlinkUTF8

### DIFF
--- a/src/fs_win32.c
+++ b/src/fs_win32.c
@@ -73,7 +73,7 @@ int fs_win32_readlinkUTF8 (const char *path, char *result, size_t rsz)
         errno = (GetLastError() == ERROR_INSUFFICIENT_BUFFER) ? ENOSPC : EINVAL;
         return -1;
     }
-    HANDLE h = CreateFileW(wbuf,0,0,0,OPEN_EXISTING,FILE_ATTRIBUTE_NORMAL,0);
+    HANDLE h = CreateFileW(wbuf,0,0,0,OPEN_EXISTING,FILE_FLAG_BACKUP_SEMANTICS,0);
     DWORD rd = (h != INVALID_HANDLE_VALUE) /*(reuse wbuf for result)*/
       ? GetFinalPathNameByHandleW(h, wbuf, sizeof(wbuf)/sizeof(*wbuf),
                                   FILE_NAME_NORMALIZED | VOLUME_NAME_NT)


### PR DESCRIPTION

This PR fixes `fs_win32_readlinkUTF8()` in `src/fs_win32.c` to support directory symbolic links and junction points on Windows.

Problem
The current implementation opens the target path using:

```c
HANDLE h = CreateFileW(wbuf, 0, 0, 0, OPEN_EXISTING,
                       FILE_ATTRIBUTE_NORMAL, 0);
```

On Windows, directories cannot be opened with `CreateFileW()` unless `FILE_FLAG_BACKUP_SEMANTICS` is specified. As a result, calling `readlink()` on symbolic links or junctions that point to directories fails with `ERROR_ACCESS_DENIED`.

Solution

Replace `FILE_ATTRIBUTE_NORMAL` with `FILE_FLAG_BACKUP_SEMANTICS` in the `CreateFileW()` call.

This allows `fs_win32_readlinkUTF8()` to open directory reparse points and correctly resolve directory symbolic links and junctions, while preserving existing behavior for file symlinks.

Verification

Rebuilt the project successfully.
Verified that opening a directory with `FILE_ATTRIBUTE_NORMAL` fails with `ERROR_ACCESS_DENIED`.
Verified that opening a directory with `FILE_FLAG_BACKUP_SEMANTICS` succeeds.
Confirmed that `readlink()` can resolve directory symbolic links and junction points after the change.
