### PR TITLE
[core] fix stat() on drive and directory roots in fs_win32_stati64UTF8

### DIFF
--- a/src/fs_win32.c
+++ b/src/fs_win32.c
@@ -47,7 +47,13 @@ int fs_win32_stati64UTF8 (const char *path, struct fs_win32_stati64UTF8 *st)
         return -1;
     }
     /* omit trailing '/' (if present) or else _WIN32 stat() fails */
-    int final_slash = (path[len-1] == '/' || path[len-1] == '\\');
+    /* do not omit for drive root (e.g. "C:/") or single slash root (e.g. "/") */
+    int final_slash = 0;
+    if (len > 1 && (path[len-1] == '/' || path[len-1] == '\\')) {
+        if (len != 3 || path[1] != ':') {
+            final_slash = 1;
+        }
+    }
     int wlen = MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS,
                                    path, len - final_slash,
                                    wbuf, (sizeof(wbuf)/sizeof(*wbuf))-1);


### PR DESCRIPTION
This PR fixes `fs_win32_stati64UTF8()` in `src/fs_win32.c` to properly handle drive root paths on Windows.

Problem

The current implementation removes a trailing slash from paths before calling `_wstati64()`.

For a drive root such as `C:/`, removing the trailing slash produces `C:`. On Windows, `C:` refers to the current directory on drive C rather than the root directory itself. As a result, `_wstati64()` may fail or return incorrect results when handling drive root paths.

 Solution

Adjust the trailing slash handling logic so that a trailing slash is removed only when the path is not a drive root.

For example, preserve paths such as:

* `C:/`
* `D:/`

by avoiding slash removal when `len == 3 && path[1] == ':'`.

This ensures that drive root paths are passed to `_wstati64()` in a form that Windows correctly interprets while preserving existing behavior for non-root paths.

Verification
 Rebuilt the project successfully.
Verified that drive root paths such as `C:/` are handled correctly.
Verified that non-root paths continue to behave as before.
