### PR TITLE
[core] add lstat() support on Windows to check symlink restrictions

### DIFF
--- a/src/fs_win32.c
+++ b/src/fs_win32.c
@@ -13,13 +13,24 @@
 /* MS filesystem API does not support UTF-8?  WTH?  write our own; not hard */
 
 #include <sys/types.h>
-#include <sys/stat.h>
-#include <direct.h>
 #include <io.h>
 
 #include <windows.h> /*(otherwise get No Target Architecture error)*/
 #include <stringapiset.h>
 #include <errno.h>
+
+#include "sys-stat.h" /*(for _S_IFLNK; include after <...> headers)*/
+
+#ifndef IO_REPARSE_TAG_SYMLINK
+#define IO_REPARSE_TAG_SYMLINK          0xA000000C
+#endif
+#ifndef IO_REPARSE_TAG_LX_SYMLINK
+#define IO_REPARSE_TAG_LX_SYMLINK       0xA000001D
+#endif
+
+#define IsReparseTagSymlink(tag) \
+    ((tag) == IO_REPARSE_TAG_SYMLINK || \
+     (tag) == IO_REPARSE_TAG_LX_SYMLINK)
 
 int fs_win32_openUTF8 (const char *path, int oflag, int pmode)
 {
@@ -117,6 +128,113 @@ int fs_win32_readlinkUTF8 (const char *path, char *result, size_t rsz)
     /*(???: should we translate '\\' to '/' in result?)*/
     result[mlen] = '\0';
     return mlen;
+}
+
+int fs_win32_lstati64UTF8 (const char *path, struct fs_win32_stati64UTF8 *st)
+{
+    WCHAR wbuf[4096];
+    size_t len = strlen(path);
+    if (0 == len) {
+        errno = EINVAL;
+        return -1;
+    }
+    /* omit trailing '/' (if present) or else _WIN32 stat() fails */
+    /* do not omit for drive root (e.g. "C:/") or single slash root (e.g. "/") */
+    int final_slash = 0;
+    if (len > 1 && (path[len-1] == '/' || path[len-1] == '\\')) {
+        if (len != 3 || path[1] != ':') {
+            final_slash = 1;
+        }
+    }
+    int wlen = MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS,
+                                   path, len - final_slash,
+                                   wbuf, (sizeof(wbuf)/sizeof(*wbuf))-1);
+    if (wlen <= 0)
+        return -1;
+    wbuf[wlen] = 0;
+
+    DWORD attr = GetFileAttributesW(wbuf);
+    if (attr == INVALID_FILE_ATTRIBUTES) {
+        return _wstati64(wbuf, (struct _stati64 *)st);
+    }
+
+    if (!(attr & FILE_ATTRIBUTE_REPARSE_POINT)) {
+        int rc = _wstati64(wbuf, (struct _stati64 *)st);
+        if (rc == 0 && final_slash && (st->st_mode & _S_IFMT) != _S_IFDIR) {
+            errno = ENOTDIR;
+            return -1;
+        }
+        return rc;
+    }
+
+    /* If a final slash was specified (e.g. "path/"), then it refers to a directory.
+     * On POSIX/Linux, lstat("symlink/") is equivalent to stat("symlink/"), meaning
+     * it follows the symlink and validates it is a directory. */
+    if (final_slash) {
+        int rc = _wstati64(wbuf, (struct _stati64 *)st);
+        if (rc == 0 && (st->st_mode & _S_IFMT) != _S_IFDIR) {
+            errno = ENOTDIR;
+            return -1;
+        }
+        return rc;
+    }
+
+    HANDLE h = CreateFileW(wbuf, 0, FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+                           NULL, OPEN_EXISTING, FILE_FLAG_OPEN_REPARSE_POINT | FILE_FLAG_BACKUP_SEMANTICS, NULL);
+    if (h == INVALID_HANDLE_VALUE) {
+        return _wstati64(wbuf, (struct _stati64 *)st);
+    }
+
+    FILE_ATTRIBUTE_TAG_INFO fati;
+    if (!GetFileInformationByHandleEx(h, FileAttributeTagInfo, &fati, sizeof(fati))) {
+        CloseHandle(h);
+        return _wstati64(wbuf, (struct _stati64 *)st);
+    }
+
+    if (!IsReparseTagSymlink(fati.ReparseTag)) {
+        CloseHandle(h);
+        int rc = _wstati64(wbuf, (struct _stati64 *)st);
+        if (rc == 0 && final_slash && (st->st_mode & _S_IFMT) != _S_IFDIR) {
+            errno = ENOTDIR;
+            return -1;
+        }
+        return rc;
+    }
+
+    BY_HANDLE_FILE_INFORMATION bhfi;
+    if (!GetFileInformationByHandle(h, &bhfi)) {
+        CloseHandle(h);
+        return _wstati64(wbuf, (struct _stati64 *)st);
+    }
+    CloseHandle(h);
+
+    memset(st, 0, sizeof(*st));
+    st->st_dev = bhfi.dwVolumeSerialNumber;
+    st->st_ino = (unsigned short)bhfi.nFileIndexLow;
+    st->st_nlink = (short)bhfi.nNumberOfLinks;
+    st->st_size = ((__int64)bhfi.nFileSizeHigh << 32) | bhfi.nFileSizeLow;
+    st->st_rdev = bhfi.dwVolumeSerialNumber;
+
+    ULARGE_INTEGER ull;
+    ull.LowPart = bhfi.ftLastAccessTime.dwLowDateTime;
+    ull.HighPart = bhfi.ftLastAccessTime.dwHighDateTime;
+    st->st_atime = (__time64_t)((ull.QuadPart - 116444736000000000ULL) / 10000000ULL);
+
+    ull.LowPart = bhfi.ftLastWriteTime.dwLowDateTime;
+    ull.HighPart = bhfi.ftLastWriteTime.dwHighDateTime;
+    st->st_mtime = (__time64_t)((ull.QuadPart - 116444736000000000ULL) / 10000000ULL);
+
+    ull.LowPart = bhfi.ftCreationTime.dwLowDateTime;
+    ull.HighPart = bhfi.ftCreationTime.dwHighDateTime;
+    st->st_ctime = (__time64_t)((ull.QuadPart - 116444736000000000ULL) / 10000000ULL);
+
+    st->st_mode = _S_IFLNK;
+    if (!(bhfi.dwFileAttributes & FILE_ATTRIBUTE_READONLY)) {
+        st->st_mode |= _S_IWRITE;
+    }
+    st->st_mode |= _S_IREAD;
+
+    return 0;
 }
 
 #endif /* _WIN32 */

--- a/src/fs_win32.h
+++ b/src/fs_win32.h
@@ -65,6 +65,10 @@ struct fs_win32_stati64UTF8 {
 /* could be inline compat func here, but fairly large func */
 int fs_win32_stati64UTF8 (const char *path, struct fs_win32_stati64UTF8 *st);
 
+#undef lstat
+#define lstat(a,b)       fs_win32_lstati64UTF8((a),(b))
+int fs_win32_lstati64UTF8 (const char *path, struct fs_win32_stati64UTF8 *st);
+
 #undef readlink
 #define readlink(a,b,c)  fs_win32_readlinkUTF8((a),(b),(c))
 int fs_win32_readlinkUTF8 (const char *path, char *result, size_t rsz);

--- a/src/sys-stat.h
+++ b/src/sys-stat.h
@@ -14,6 +14,13 @@
 
 #ifdef _WIN32
 
+#ifndef _S_IFLNK
+#define _S_IFLNK 0xA000
+#endif
+#ifndef HAVE_LSTAT
+#define HAVE_LSTAT 1
+#endif
+
 #ifndef S_IRWXU
 #define S_IRWXU (_S_IREAD | _S_IWRITE | _S_IEXEC)
 #endif


### PR DESCRIPTION
On Windows, lstat() was mapped directly to stat(), which follows symbolic links. As a result, symbolic links could not be distinguished from their targets, causing symlink checks and restrictions such as server.follow-symlink = "disable" to be ineffective.

This PR adds Windows-specific lstat() support to enable proper detection of symbolic links and directory junctions. It defines _S_IFLNK as 0xA000 and enables HAVE_LSTAT under _WIN32, maps lstat() to fs_win32_lstati64UTF8(), and implements fs_win32_lstati64UTF8() in src/fs_win32.c. The implementation detects reparse points (symbolic links and directory junctions), falls back to fs_win32_stati64UTF8() for non-reparse-point paths, and opens reparse points using FILE_FLAG_OPEN_REPARSE_POINT | FILE_FLAG_BACKUP_SEMANTICS so that information about the link itself is retrieved rather than the target. Detected links are marked with _S_IFLNK in st_mode.

Paths ending with a trailing slash continue to fall back to normal stat() behavior, matching POSIX path resolution semantics. With these changes, Windows builds can correctly identify symbolic links and junctions, allowing existing symlink restriction checks to function as intended