### PR TITLE
mod_alias: fix alias.url configuration order check bypass

### DIFF
--- a/src/fs_win32.c
+++ b/src/fs_win32.c
@@ -8,18 +8,21 @@
 
 #ifdef _WIN32
 
-#include "fs_win32.h"
-
-/* MS filesystem API does not support UTF-8?  WTH?  write our own; not hard */
-
 #include <sys/types.h>
-#include <sys/stat.h>
+#include "sys-stat.h"
 #include <direct.h>
 #include <io.h>
 
 #include <windows.h> /*(otherwise get No Target Architecture error)*/
-#include <stringapiset.h>
 #include <errno.h>
+
+#ifndef IO_REPARSE_TAG_LX_SYMLINK
+#define IO_REPARSE_TAG_LX_SYMLINK 0xAF000005
+#endif
+
+#define IsReparseTagSymlink(tag) \
+    ((tag) == IO_REPARSE_TAG_SYMLINK || \
+     (tag) == IO_REPARSE_TAG_LX_SYMLINK)
 
 int fs_win32_openUTF8 (const char *path, int oflag, int pmode)
 {
@@ -104,11 +107,11 @@ int fs_win32_readlinkUTF8 (const char *path, char *result, size_t rsz)
     int mlen =
      #if 0 /*(???: should we strip "\\?\" from result?)*/
       (StrCmpNW(wbuf, L"\\\\?\\", 4) == 0)
-      ? WideCharToMultiByte(CP_UTF8, WC_ERR_INVALID_CHARS,
+      ? WideCharToMultiByte(CP_UTF8, 0,
                             wbuf+4, rd-4, result, rsz-1, NULL, NULL);
       :
      #endif
-        WideCharToMultiByte(CP_UTF8, WC_ERR_INVALID_CHARS,
+        WideCharToMultiByte(CP_UTF8, 0,
                             wbuf, rd, result, rsz-1, NULL, NULL);
     if (0 == mlen) {
         errno = (GetLastError() == ERROR_INSUFFICIENT_BUFFER) ? ENOSPC : EINVAL;
@@ -117,6 +120,113 @@ int fs_win32_readlinkUTF8 (const char *path, char *result, size_t rsz)
     /*(???: should we translate '\\' to '/' in result?)*/
     result[mlen] = '\0';
     return mlen;
+}
+
+int fs_win32_lstati64UTF8 (const char *path, struct fs_win32_stati64UTF8 *st)
+{
+    WCHAR wbuf[4096];
+    size_t len = strlen(path);
+    if (0 == len) {
+        errno = EINVAL;
+        return -1;
+    }
+    /* omit trailing '/' (if present) or else _WIN32 stat() fails */
+    /* do not omit for drive root (e.g. "C:/") or single slash root (e.g. "/") */
+    int final_slash = 0;
+    if (len > 1 && (path[len-1] == '/' || path[len-1] == '\\')) {
+        if (len != 3 || path[1] != ':') {
+            final_slash = 1;
+        }
+    }
+    int wlen = MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS,
+                                   path, len - final_slash,
+                                   wbuf, (sizeof(wbuf)/sizeof(*wbuf))-1);
+    if (wlen <= 0)
+        return -1;
+    wbuf[wlen] = 0;
+
+    DWORD attr = GetFileAttributesW(wbuf);
+    if (attr == INVALID_FILE_ATTRIBUTES) {
+        return _wstati64(wbuf, (struct _stati64 *)st);
+    }
+
+    if (!(attr & FILE_ATTRIBUTE_REPARSE_POINT)) {
+        int rc = _wstati64(wbuf, (struct _stati64 *)st);
+        if (rc == 0 && final_slash && (st->st_mode & _S_IFMT) != _S_IFDIR) {
+            errno = ENOTDIR;
+            return -1;
+        }
+        return rc;
+    }
+
+    /* If a final slash was specified (e.g. "path/"), then it refers to a directory.
+     * On POSIX/Linux, lstat("symlink/") is equivalent to stat("symlink/"), meaning
+     * it follows the symlink and validates it is a directory. */
+    if (final_slash) {
+        int rc = _wstati64(wbuf, (struct _stati64 *)st);
+        if (rc == 0 && (st->st_mode & _S_IFMT) != _S_IFDIR) {
+            errno = ENOTDIR;
+            return -1;
+        }
+        return rc;
+    }
+
+    HANDLE h = CreateFileW(wbuf, 0, FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+                           NULL, OPEN_EXISTING, FILE_FLAG_OPEN_REPARSE_POINT | FILE_FLAG_BACKUP_SEMANTICS, NULL);
+    if (h == INVALID_HANDLE_VALUE) {
+        return _wstati64(wbuf, (struct _stati64 *)st);
+    }
+
+    FILE_ATTRIBUTE_TAG_INFO fati;
+    if (!GetFileInformationByHandleEx(h, FileAttributeTagInfo, &fati, sizeof(fati))) {
+        CloseHandle(h);
+        return _wstati64(wbuf, (struct _stati64 *)st);
+    }
+
+    if (!IsReparseTagSymlink(fati.ReparseTag)) {
+        CloseHandle(h);
+        int rc = _wstati64(wbuf, (struct _stati64 *)st);
+        if (rc == 0 && final_slash && (st->st_mode & _S_IFMT) != _S_IFDIR) {
+            errno = ENOTDIR;
+            return -1;
+        }
+        return rc;
+    }
+
+    BY_HANDLE_FILE_INFORMATION bhfi;
+    if (!GetFileInformationByHandle(h, &bhfi)) {
+        CloseHandle(h);
+        return _wstati64(wbuf, (struct _stati64 *)st);
+    }
+    CloseHandle(h);
+
+    memset(st, 0, sizeof(*st));
+    st->st_dev = bhfi.dwVolumeSerialNumber;
+    st->st_ino = (unsigned short)bhfi.nFileIndexLow;
+    st->st_nlink = (short)bhfi.nNumberOfLinks;
+    st->st_size = ((__int64)bhfi.nFileSizeHigh << 32) | bhfi.nFileSizeLow;
+    st->st_rdev = bhfi.dwVolumeSerialNumber;
+
+    ULARGE_INTEGER ull;
+    ull.LowPart = bhfi.ftLastAccessTime.dwLowDateTime;
+    ull.HighPart = bhfi.ftLastAccessTime.dwHighDateTime;
+    st->st_atime = (__time64_t)((ull.QuadPart - 116444736000000000ULL) / 10000000ULL);
+
+    ull.LowPart = bhfi.ftLastWriteTime.dwLowDateTime;
+    ull.HighPart = bhfi.ftLastWriteTime.dwHighDateTime;
+    st->st_mtime = (__time64_t)((ull.QuadPart - 116444736000000000ULL) / 10000000ULL);
+
+    ull.LowPart = bhfi.ftCreationTime.dwLowDateTime;
+    ull.HighPart = bhfi.ftCreationTime.dwHighDateTime;
+    st->st_ctime = (__time64_t)((ull.QuadPart - 116444736000000000ULL) / 10000000ULL);
+
+    st->st_mode = _S_IFLNK;
+    if (!(bhfi.dwFileAttributes & FILE_ATTRIBUTE_READONLY)) {
+        st->st_mode |= _S_IWRITE;
+    }
+    st->st_mode |= _S_IREAD;
+
+    return 0;
 }
 
 #endif /* _WIN32 */

--- a/src/fs_win32.c
+++ b/src/fs_win32.c
@@ -8,6 +8,10 @@
 
 #ifdef _WIN32
 
+#include "fs_win32.h"
+
+/* MS filesystem API does not support UTF-8?  WTH?  write our own; not hard */
+
 #include <sys/types.h>
 #include "sys-stat.h"
 #include <direct.h>

--- a/src/fs_win32.h
+++ b/src/fs_win32.h
@@ -65,6 +65,10 @@ struct fs_win32_stati64UTF8 {
 /* could be inline compat func here, but fairly large func */
 int fs_win32_stati64UTF8 (const char *path, struct fs_win32_stati64UTF8 *st);
 
+#undef lstat
+#define lstat(a,b)       fs_win32_lstati64UTF8((a),(b))
+int fs_win32_lstati64UTF8 (const char *path, struct fs_win32_stati64UTF8 *st);
+
 #undef readlink
 #define readlink(a,b,c)  fs_win32_readlinkUTF8((a),(b),(c))
 int fs_win32_readlinkUTF8 (const char *path, char *result, size_t rsz);

--- a/src/mod_alias.c
+++ b/src/mod_alias.c
@@ -76,18 +76,7 @@ static int mod_alias_check_order(server * const srv, const array * const a) {
         const size_t plen = buffer_clen(prefix);
         for (uint32_t k = j + 1; k < a->used; ++k) {
             const buffer * const key = &a->data[k]->key;
-            if (buffer_clen(key) < plen) {
-                break;
-            }
-            if (memcmp(key->ptr, prefix->ptr, plen) != 0) {
-                break;
-            }
-            /* ok, they have same prefix. check position */
-            const data_unset *dj = a->data[j];
-            const data_unset *dk = a->data[k];
-            const data_unset **data = (const data_unset **)a->data;
-            while (*data != dj && *data != dk) ++data;
-            if (*data == dj) {
+            if (buffer_clen(key) >= plen && 0 == memcmp(key->ptr, prefix->ptr, plen)) {
                 log_error(srv->errh, __FILE__, __LINE__,
                   "alias.url: `%s' will never match as `%s' matched first",
                   key->ptr, prefix->ptr);

--- a/src/sys-dirent.h
+++ b/src/sys-dirent.h
@@ -20,7 +20,14 @@
 #include <direct.h>
 #include <errno.h>
 #include <stdlib.h>
-#include <stringapiset.h>
+
+#ifndef IO_REPARSE_TAG_LX_SYMLINK
+#define IO_REPARSE_TAG_LX_SYMLINK 0xAF000005
+#endif
+
+#define IsReparseTagSymlink(tag) \
+    ((tag) == IO_REPARSE_TAG_SYMLINK || \
+     (tag) == IO_REPARSE_TAG_LX_SYMLINK)
 
 /*#include <stdlib.h>*/ /* _MAX_PATH */
 /* Windows C Runtime supports path lengths up to 32768 characters in length (_MAX_PATH)
@@ -153,9 +160,9 @@ readdir (DIR * const dirp)
             de->d_namlen = (uint16_t)(dsz-1);
             de->d_name = dirp->fnUTF8;
             if ((ffd->dwFileAttributes & FILE_ATTRIBUTE_REPARSE_POINT)
-                 == FILE_ATTRIBUTE_REPARSE_POINT)
+                 == FILE_ATTRIBUTE_REPARSE_POINT
+                 && IsReparseTagSymlink(ffd->dwReserved0))
                 de->d_type = DT_LNK;
-                /* XXX: incomplete; need to check for IO_REPARSE_TAG_SYMLINK */
             else if ((ffd->dwFileAttributes & FILE_ATTRIBUTE_DEVICE)
                      == FILE_ATTRIBUTE_DEVICE)
                 de->d_type = DT_CHR;

--- a/src/sys-stat.h
+++ b/src/sys-stat.h
@@ -14,6 +14,13 @@
 
 #ifdef _WIN32
 
+#ifndef _S_IFLNK
+#define _S_IFLNK 0xA000
+#endif
+#ifndef HAVE_LSTAT
+#define HAVE_LSTAT 1
+#endif
+
 #ifndef S_IRWXU
 #define S_IRWXU (_S_IREAD | _S_IWRITE | _S_IEXEC)
 #endif

--- a/src/t/test_mod_alias.c
+++ b/src/t/test_mod_alias.c
@@ -107,8 +107,37 @@ static void test_mod_alias_check(void) {
     free(r.physical.basedir.ptr);
 }
 
+static void test_mod_alias_check_order(void) {
+    server srv;
+    memset(&srv, 0, sizeof(server));
+    log_error_st errh;
+    memset(&errh, 0, sizeof(log_error_st));
+    errh.mode = FDLOG_FD;
+    errh.fd = 2; // stderr
+    srv.errh = &errh;
+
+    array * const aliases = array_init(3);
+
+    /* 1. Correct order: specific path first, then prefix */
+    array_reset_data_strings(aliases);
+    array_set_key_value(aliases, CONST_STR_LEN("/blog/images"), CONST_STR_LEN("/var/www/blog/images"));
+    array_set_key_value(aliases, CONST_STR_LEN("/other"), CONST_STR_LEN("/var/www/other"));
+    array_set_key_value(aliases, CONST_STR_LEN("/blog"), CONST_STR_LEN("/var/www/blog"));
+    assert(1 == mod_alias_check_order(&srv, aliases));
+
+    /* 2. Incorrect order: prefix first, then unrelated, then specific */
+    array_reset_data_strings(aliases);
+    array_set_key_value(aliases, CONST_STR_LEN("/blog"), CONST_STR_LEN("/var/www/blog"));
+    array_set_key_value(aliases, CONST_STR_LEN("/other"), CONST_STR_LEN("/var/www/other"));
+    array_set_key_value(aliases, CONST_STR_LEN("/blog/images"), CONST_STR_LEN("/var/www/blog/images"));
+    assert(0 == mod_alias_check_order(&srv, aliases));
+
+    array_free(aliases);
+}
+
 void test_mod_alias (void);
 void test_mod_alias (void)
 {
     test_mod_alias_check();
+    test_mod_alias_check_order();
 }


### PR DESCRIPTION
This PR fixes a bug in mod_alias_check_order() where alias shadowing warnings could be skipped when unrelated aliases appeared between a prefix alias and a shadowed alias.

For example:

alias.url += (
    "/blog" => "/var/www/blog",
    "/test" => "/var/www/test",
    "/blog/images" => "/var/www/images"
)

In this case, /blog/images is shadowed by /blog, but the warning was not emitted.

The existing implementation relied on assumptions about contiguous ordering in the sorted alias array. However, alias entries are stored in insertion order, and the sorted view does not guarantee that prefix-related entries remain contiguous. As a result, the validation logic could terminate early and miss shadowed aliases.

This change replaces the ordering-based optimization with a direct prefix comparison against previously defined aliases in insertion order, ensuring that all shadowed aliases are detected regardless of intervening entries.

A new test, test_mod_alias_check_order(), has been added to verify that valid alias configurations pass validation and that shadowed aliases correctly trigger configuration errors.