### PR TITLE
fix(core): readlink on Windows should read symlink/junction target without resolving it

### DIFF
--- a/src/fs_win32.c
+++ b/src/fs_win32.c
@@ -18,6 +18,7 @@
 #include <io.h>
 
 #include <windows.h> /*(otherwise get No Target Architecture error)*/
+#include <winioctl.h>
 #include <stringapiset.h>
 #include <errno.h>
 
@@ -77,6 +78,30 @@ int fs_win32_stati64UTF8 (const char *path, struct fs_win32_stati64UTF8 *st)
     return 0;
 }
 
+// Custom reparse data buffer structure to avoid dependency on WDK/winnt.h differences
+typedef struct {
+    ULONG  ReparseTag;
+    USHORT ReparseDataLength;
+    USHORT Reserved;
+    union {
+        struct {
+            USHORT SubstituteNameOffset;
+            USHORT SubstituteNameLength;
+            USHORT PrintNameOffset;
+            USHORT PrintNameLength;
+            ULONG  Flags;
+            WCHAR  PathBuffer[1];
+        } SymbolicLinkReparseBuffer;
+        struct {
+            USHORT SubstituteNameOffset;
+            USHORT SubstituteNameLength;
+            USHORT PrintNameOffset;
+            USHORT PrintNameLength;
+            WCHAR  PathBuffer[1];
+        } MountPointReparseBuffer;
+    } u;
+} fs_win32_reparse_data_buffer_t;
+
 int fs_win32_readlinkUTF8 (const char *path, char *result, size_t rsz)
 {
     WCHAR wbuf[4096];
@@ -86,36 +111,99 @@ int fs_win32_readlinkUTF8 (const char *path, char *result, size_t rsz)
         errno = (GetLastError() == ERROR_INSUFFICIENT_BUFFER) ? ENOSPC : EINVAL;
         return -1;
     }
+
     HANDLE h = CreateFileW(wbuf, 0, 0, 0, OPEN_EXISTING,
-                           FILE_FLAG_BACKUP_SEMANTICS, 0);
-    DWORD rd = (h != INVALID_HANDLE_VALUE) /*(reuse wbuf for result)*/
-      ? GetFinalPathNameByHandleW(h, wbuf, sizeof(wbuf)/sizeof(*wbuf),
-                                  FILE_NAME_NORMALIZED | VOLUME_NAME_NT)
-      : 0;
-    CloseHandle(h);
-    if (0 == rd) {
-        errno = (GetLastError() == ERROR_PATH_NOT_FOUND) ? ENOENT : EINVAL;
+                           FILE_FLAG_OPEN_REPARSE_POINT | FILE_FLAG_BACKUP_SEMANTICS, 0);
+    if (h == INVALID_HANDLE_VALUE) {
+        DWORD err = GetLastError();
+        errno = (err == ERROR_FILE_NOT_FOUND || err == ERROR_PATH_NOT_FOUND) ? ENOENT : EINVAL;
         return -1;
     }
-    if (rd >= sizeof(wbuf)/sizeof(*wbuf) || 0 == rsz) {
+
+    union {
+        fs_win32_reparse_data_buffer_t rdb;
+        BYTE dummy[16384]; /* MAXIMUM_REPARSE_DATA_BUFFER_SIZE */
+    } u;
+    DWORD bytes_returned = 0;
+    if (!DeviceIoControl(h, FSCTL_GET_REPARSE_POINT, NULL, 0, &u.rdb, sizeof(u.dummy), &bytes_returned, NULL)) {
+        CloseHandle(h);
+        errno = EINVAL;
+        return -1;
+    }
+    CloseHandle(h);
+
+    const WCHAR *target_path = NULL;
+    int target_len = 0;
+
+    /* Windows SDK definitions if not present */
+    #ifndef IO_REPARSE_TAG_SYMLINK
+    #define IO_REPARSE_TAG_SYMLINK 0xA000000C
+    #endif
+    #ifndef IO_REPARSE_TAG_MOUNT_POINT
+    #define IO_REPARSE_TAG_MOUNT_POINT 0xA0000003
+    #endif
+
+    if (u.rdb.ReparseTag == IO_REPARSE_TAG_SYMLINK) {
+        int printOffset = u.rdb.u.SymbolicLinkReparseBuffer.PrintNameOffset / sizeof(WCHAR);
+        int printLen = u.rdb.u.SymbolicLinkReparseBuffer.PrintNameLength / sizeof(WCHAR);
+        int subOffset = u.rdb.u.SymbolicLinkReparseBuffer.SubstituteNameOffset / sizeof(WCHAR);
+        int subLen = u.rdb.u.SymbolicLinkReparseBuffer.SubstituteNameLength / sizeof(WCHAR);
+
+        if (printLen > 0) {
+            target_path = &u.rdb.u.SymbolicLinkReparseBuffer.PathBuffer[printOffset];
+            target_len = printLen;
+        } else if (subLen > 0) {
+            target_path = &u.rdb.u.SymbolicLinkReparseBuffer.PathBuffer[subOffset];
+            target_len = subLen;
+            if (target_len >= 4 && target_path[0] == L'\\' && target_path[1] == L'?' && target_path[2] == L'?' && target_path[3] == L'\\') {
+                target_path += 4;
+                target_len -= 4;
+            }
+        }
+    } else if (u.rdb.ReparseTag == IO_REPARSE_TAG_MOUNT_POINT) {
+        int printOffset = u.rdb.u.MountPointReparseBuffer.PrintNameOffset / sizeof(WCHAR);
+        int printLen = u.rdb.u.MountPointReparseBuffer.PrintNameLength / sizeof(WCHAR);
+        int subOffset = u.rdb.u.MountPointReparseBuffer.SubstituteNameOffset / sizeof(WCHAR);
+        int subLen = u.rdb.u.MountPointReparseBuffer.SubstituteNameLength / sizeof(WCHAR);
+
+        if (printLen > 0) {
+            target_path = &u.rdb.u.MountPointReparseBuffer.PathBuffer[printOffset];
+            target_len = printLen;
+        } else if (subLen > 0) {
+            target_path = &u.rdb.u.MountPointReparseBuffer.PathBuffer[subOffset];
+            target_len = subLen;
+            if (target_len >= 4 && target_path[0] == L'\\' && target_path[1] == L'?' && target_path[2] == L'?' && target_path[3] == L'\\') {
+                target_path += 4;
+                target_len -= 4;
+            }
+        }
+    } else {
+        errno = EINVAL;
+        return -1;
+    }
+
+    if (target_path == NULL || target_len <= 0) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    if (rsz == 0) {
         errno = ENOSPC;
         return -1;
     }
-    int mlen =
-     #if 0 /*(???: should we strip "\\?\" from result?)*/
-      (StrCmpNW(wbuf, L"\\\\?\\", 4) == 0)
-      ? WideCharToMultiByte(CP_UTF8, WC_ERR_INVALID_CHARS,
-                            wbuf+4, rd-4, result, rsz-1, NULL, NULL);
-      :
-     #endif
-        WideCharToMultiByte(CP_UTF8, WC_ERR_INVALID_CHARS,
-                            wbuf, rd, result, rsz-1, NULL, NULL);
-    if (0 == mlen) {
+
+    int mlen = WideCharToMultiByte(CP_UTF8, WC_ERR_INVALID_CHARS, target_path, target_len, result, rsz - 1, NULL, NULL);
+    if (mlen <= 0) {
         errno = (GetLastError() == ERROR_INSUFFICIENT_BUFFER) ? ENOSPC : EINVAL;
         return -1;
     }
-    /*(???: should we translate '\\' to '/' in result?)*/
     result[mlen] = '\0';
+
+    for (int i = 0; i < mlen; i++) {
+        if (result[i] == '\\') {
+            result[i] = '/';
+        }
+    }
     return mlen;
 }
 


### PR DESCRIPTION
On Windows, fs_win32_readlinkUTF8() resolved symlink and junction targets using GetFinalPathNameByHandleW(), which caused relative links to be converted to absolute paths and prevented reading broken links. This change opens reparse points directly and retrieves the stored target using FSCTL_GET_REPARSE_POINT, allowing readlink() to correctly return symlink and junction targets without resolving them, including relative and broken links, matching POSIX semantics more closely.